### PR TITLE
feat: cross-platform automated packaging via Nuitka and GitHub Actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,9 +101,22 @@ jobs:
           path: artifacts
           merge-multiple: true
       
-      - name: Create Release
+      - name: Create Official Release
+        if: startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@v2
         with:
+          files: |
+            artifacts/Immich-Go-GUI-Windows.exe
+            artifacts/Immich-Go-GUI-macOS.dmg
+            artifacts/Immich-Go-GUI-Linux.AppImage
+
+      - name: Create Test Pre-Release
+        if: ${{ !startsWith(github.ref, 'refs/tags/') }}
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: test-build
+          name: "Test Build (Unofficial)"
+          prerelease: true
           files: |
             artifacts/Immich-Go-GUI-Windows.exe
             artifacts/Immich-Go-GUI-macOS.dmg

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,8 @@ name: Build and Release Apps
 on:
   workflow_dispatch:
   push:
+    branches:
+      - chore/nuitka-packaging
     tags:
       - 'v*'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,106 @@
+name: Build and Release Apps
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-22.04
+            name: linux
+          - os: windows-latest
+            name: windows
+          - os: macos-latest
+            name: macos
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v2
+
+      - name: Install dependencies
+        run: uv sync
+
+      - name: Add Nuitka
+        run: uv add --dev nuitka
+
+      # --- WINDOWS BUILD ---
+      - name: Build Windows
+        if: matrix.name == 'windows'
+        run: |
+          uv run python -m nuitka --onefile --windows-console-mode=disable --enable-plugin=pyside6 --include-data-files=immich-go-gui-icon.svg=immich-go-gui-icon.svg app.py
+          mv app.exe Immich-Go-GUI-Windows.exe
+
+      # --- MACOS BUILD ---
+      - name: Build macOS
+        if: matrix.name == 'macos'
+        run: |
+          uv run python -m nuitka --macos-create-app-bundle --enable-plugin=pyside6 --include-data-files=immich-go-gui-icon.svg=immich-go-gui-icon.svg app.py
+          npm install -g create-dmg
+          create-dmg app.app || true
+          mv *.dmg Immich-Go-GUI-macOS.dmg
+
+      # --- LINUX APPIMAGE BUILD ---
+      - name: Build Linux AppImage
+        if: matrix.name == 'linux'
+        run: |
+          uv run python -m nuitka --standalone --enable-plugin=pyside6 --include-data-files=immich-go-gui-icon.svg=immich-go-gui-icon.svg app.py
+          
+          mkdir -p AppDir/usr/bin
+          cp -r app.dist/* AppDir/usr/bin/
+          cp immich-go-gui-icon.svg AppDir/
+          
+          cat << 'EOF' > AppDir/immich-go-gui.desktop
+          [Desktop Entry]
+          Name=Immich-Go GUI
+          Exec=app.bin
+          Icon=immich-go-gui-icon
+          Type=Application
+          Categories=Utility;
+          EOF
+          
+          cat << 'EOF' > AppDir/AppRun
+          #!/bin/sh
+          HERE="$(dirname "$(readlink -f "${0}")")"
+          exec "${HERE}/usr/bin/app.bin" "$@"
+          EOF
+          chmod +x AppDir/AppRun
+          
+          wget -q https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage -O appimagetool
+          chmod +x appimagetool
+          ./appimagetool --appimage-extract-and-run AppDir Immich-Go-GUI-Linux.AppImage
+
+      # --- UPLOAD ARTIFACTS ---
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: Immich-Go-GUI-${{ matrix.name }}
+          path: |
+            Immich-Go-GUI-Windows.exe
+            Immich-Go-GUI-macOS.dmg
+            Immich-Go-GUI-Linux.AppImage
+
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          merge-multiple: true
+      
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            artifacts/Immich-Go-GUI-Windows.exe
+            artifacts/Immich-Go-GUI-macOS.dmg
+            artifacts/Immich-Go-GUI-Linux.AppImage

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,7 @@
 name: Build and Release Apps
 
 on:
+  workflow_dispatch:
   push:
     tags:
       - 'v*'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,14 +38,14 @@ jobs:
       - name: Build Windows
         if: matrix.name == 'windows'
         run: |
-          uv run python -m nuitka --onefile --windows-console-mode=disable --enable-plugin=pyside6 --include-data-files=immich-go-gui-icon.svg=immich-go-gui-icon.svg app.py
+          uv run python -m nuitka --assume-yes-for-downloads --onefile --windows-console-mode=disable --enable-plugin=pyside6 --include-data-files=immich-go-gui-icon.svg=immich-go-gui-icon.svg app.py
           mv app.exe Immich-Go-GUI-Windows.exe
 
       # --- MACOS BUILD ---
       - name: Build macOS
         if: matrix.name == 'macos'
         run: |
-          uv run python -m nuitka --macos-create-app-bundle --enable-plugin=pyside6 --include-data-files=immich-go-gui-icon.svg=immich-go-gui-icon.svg app.py
+          uv run python -m nuitka --assume-yes-for-downloads --macos-create-app-bundle --enable-plugin=pyside6 --include-data-files=immich-go-gui-icon.svg=immich-go-gui-icon.svg app.py
           npm install -g create-dmg
           create-dmg app.app || true
           mv *.dmg Immich-Go-GUI-macOS.dmg
@@ -54,7 +54,7 @@ jobs:
       - name: Build Linux AppImage
         if: matrix.name == 'linux'
         run: |
-          uv run python -m nuitka --standalone --enable-plugin=pyside6 --include-data-files=immich-go-gui-icon.svg=immich-go-gui-icon.svg app.py
+          uv run python -m nuitka --assume-yes-for-downloads --standalone --enable-plugin=pyside6 --include-data-files=immich-go-gui-icon.svg=immich-go-gui-icon.svg app.py
           
           mkdir -p AppDir/usr/bin
           cp -r app.dist/* AppDir/usr/bin/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,7 @@ jobs:
   build:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         include:
           - os: ubuntu-22.04

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ apper.py
 *.dmg
 *.AppImage
 AppDir/
+
+# Personal documentation
+GitReadme.md

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,13 @@ apper.py
 
 # Testing
 .pytest_cache/
+
+# Nuitka and Packaging artifacts
+*.build/
+*.dist/
+*.bin
+*.exe
+*.app/
+*.dmg
+*.AppImage
+AppDir/

--- a/app.py
+++ b/app.py
@@ -1249,6 +1249,15 @@ class ImmichGoGUI(QMainWindow):
 
 if __name__ == "__main__":
     app = QApplication(sys.argv)
+    
+    # Set app metadata for Wayland/X11 to correctly match the desktop file and icon
+    app.setApplicationName("Immich-Go-GUI")
+    app.setDesktopFileName("immich-go-gui")
+    
+    # Set application icon
+    icon_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "immich-go-gui-icon.svg")
+    app.setWindowIcon(QIcon(icon_path))
+    
     app.setStyle("Fusion")
     from PySide6.QtGui import QFont
     app.setFont(QFont("Segoe UI", 10))

--- a/immich-go-gui-icon.svg
+++ b/immich-go-gui-icon.svg
@@ -1,0 +1,51 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <defs>
+    <linearGradient id="bgGrad" x1="0" y1="0" x2="512" y2="512" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#1c1d26"/>
+      <stop offset="1" stop-color="#101116"/>
+    </linearGradient>
+
+    <radialGradient id="glow" cx="256" cy="256" r="230" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#ff7a3d" stop-opacity="0.30"/>
+      <stop offset="0.6" stop-color="#ff7a3d" stop-opacity="0.10"/>
+      <stop offset="1" stop-color="#ff7a3d" stop-opacity="0"/>
+    </radialGradient>
+
+    <!-- gradient coordinates are in the mark's own 0-48 space, since it is applied to paths inside the scaled/translated group -->
+    <linearGradient id="markGrad" x1="4" y1="4" x2="44" y2="44" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#ffd9a8"/>
+      <stop offset="1" stop-color="#ff4d4d"/>
+    </linearGradient>
+
+    <linearGradient id="topSheen" x1="0" y1="16" x2="0" y2="260" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#ffffff" stop-opacity="0.08"/>
+      <stop offset="1" stop-color="#ffffff" stop-opacity="0"/>
+    </linearGradient>
+
+    <clipPath id="squircle">
+      <rect x="16" y="16" width="480" height="480" rx="110" ry="110"/>
+    </clipPath>
+  </defs>
+
+  <!-- background -->
+  <rect x="16" y="16" width="480" height="480" rx="110" ry="110" fill="url(#bgGrad)"/>
+
+  <g clip-path="url(#squircle)">
+    <!-- safelight glow -->
+    <circle cx="256" cy="256" r="230" fill="url(#glow)"/>
+
+    <!-- Immich pinwheel mark, recolored and centered -->
+    <g transform="translate(106,106) scale(6.25)" fill="none" stroke="url(#markGrad)" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M26.48 30.008s7.565 1.264 13.794-1.58c4.371-1.996 5.646-6.196 4.09-10.985c-1.556-4.79-6.498-8.063-11.068-6.578c-.063 11.715-6.816 19.143-6.816 19.143"/>
+      <path d="M18.873 28.26s1.135 7.585 5.765 12.63c3.25 3.541 7.637 3.456 11.711.496s5.66-8.672 2.836-12.56c-11.16 3.56-20.312-.566-20.312-.566"/>
+      <path d="M18.184 20.485s-6.863 3.423-10.23 9.386c-2.364 4.184-.927 8.331 3.148 11.291s9.996 2.704 12.82-1.184c-6.835-9.514-5.738-19.493-5.738-19.493"/>
+      <path d="M25.366 17.427s-5.377-5.47-12.088-6.83c-4.71-.954-8.21 1.695-9.766 6.484c-1.556 4.79.518 10.343 5.088 11.828c6.937-9.441 16.766-11.482 16.766-11.482"/>
+      <path d="M30.493 23.313s3.54-6.804 2.76-13.607c-.548-4.774-4.148-7.284-9.184-7.284s-9.676 3.688-9.676 8.493c11.122 3.68 16.1 12.398 16.1 12.398"/>
+    </g>
+
+    <!-- glass sheen -->
+    <rect x="16" y="16" width="480" height="480" rx="110" ry="110" fill="url(#topSheen)"/>
+  </g>
+
+  <rect x="16.5" y="16.5" width="479" height="479" rx="109.5" ry="109.5" fill="none" stroke="#00000055" stroke-width="1"/>
+</svg>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
 
 [dependency-groups]
 dev = [
+    "nuitka>=4.1.3",
     "pytest>=9.1.1",
     "pytest-qt>=4.5.0",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -89,6 +89,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "nuitka" },
     { name = "pytest" },
     { name = "pytest-qt" },
 ]
@@ -102,6 +103,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "nuitka", specifier = ">=4.1.3" },
     { name = "pytest", specifier = ">=9.1.1" },
     { name = "pytest-qt", specifier = ">=4.5.0" },
 ]
@@ -114,6 +116,12 @@ sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
 ]
+
+[[package]]
+name = "nuitka"
+version = "4.1.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3f/d8/bdb7febea4b4fe5d3d6fe2610f946771f03e792e05a5e8ec00b62c00b265/nuitka-4.1.3.tar.gz", hash = "sha256:838ff8899dc2f0b652d4fcf6c5d7466cb7ad5abcb005668ac622d1e40f4d8a8d", size = 4565475, upload-time = "2026-06-21T10:48:04.369Z" }
 
 [[package]]
 name = "packaging"


### PR DESCRIPTION
## Overview
This PR introduces a fully automated CI/CD pipeline using GitHub Actions to package and distribute the Immich-Go GUI across Windows, macOS, and Linux. It also resolves a Linux-specific issue where the app icon was not rendering correctly under Wayland.

## Key Changes
- **Icon Fix:** Configured PySide6 Application metadata and `QIcon` paths to ensure the `immich-go-gui-icon.svg` 
- **Nuitka Compilation:** Integrated the Nuitka compiler via `uv` to build standalone binaries that launch instantly without requiring users to install Python. 
- **Cross-Platform Matrix Builds:**
  - 🪟 **Windows:** Builds a single standalone `.exe` file. Hidden idle background terminal while retaining the native CLI console spawn.
  - 🍏 **macOS:** Builds an `.app` bundle and packages it inside a drag-and-drop `.dmg` installer.
  - 🐧 **Linux:** Bundles dependencies into an `AppDir` and outputs a zero-extraction `.AppImage` with full system integration (SVG icon + Desktop file).
- **Automated Releases:** 
  - Official version tags (e.g., `v1.0.0`) automatically trigger the workflow and publish a formal GitHub Release.
  - Branch pushes and manual workflow runs automatically overwrite a `test-build` Pre-Release, enabling easy access to testing packages without cluttering the repo's official releases.
- **Housekeeping:** Added Nuitka and packaging artifacts to `.gitignore` and included personal local documentation.
