### PR TITLE
fix(ci): add windows metadata and .exe icon injection

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,6 +60,7 @@ jobs:
       # --- WINDOWS BUILD ---
       - name: Build Windows
         if: matrix.name == 'windows'
+        shell: bash
         run: |
           uv run python -c "from PIL import Image; Image.open('immich-go-gui.png').save('immich-go-gui.ico')"
           NUMERIC_VERSION=$(echo "${{ env.VERSION }}" | grep -oE '^[0-9]+\.[0-9]+\.[0-9]+' || echo "1.0.0")

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,14 +54,16 @@ jobs:
       - name: Install dependencies
         run: uv sync
 
-      - name: Add Nuitka
-        run: uv add --dev nuitka
+      - name: Add Build Tools
+        run: uv add --dev nuitka pillow
 
       # --- WINDOWS BUILD ---
       - name: Build Windows
         if: matrix.name == 'windows'
         run: |
-          uv run python -m nuitka --assume-yes-for-downloads --standalone --windows-console-mode=disable --enable-plugin=pyside6 --include-data-files=immich-go-gui.png=immich-go-gui.png app.py
+          uv run python -c "from PIL import Image; Image.open('immich-go-gui.png').save('immich-go-gui.ico')"
+          NUMERIC_VERSION=$(echo "${{ env.VERSION }}" | grep -oE '^[0-9]+\.[0-9]+\.[0-9]+' || echo "1.0.0")
+          uv run python -m nuitka --assume-yes-for-downloads --standalone --windows-console-mode=disable --enable-plugin=pyside6 --windows-icon-from-ico=immich-go-gui.ico --company-name="Shitan198u" --product-name="Immich-Go GUI" --file-version="${NUMERIC_VERSION}.0" --product-version="${NUMERIC_VERSION}.0" --file-description="Immich-Go Graphical User Interface" --copyright="MIT License" --include-data-files=immich-go-gui.png=immich-go-gui.png app.py
 
       - name: Create Windows Portable Archive
         if: matrix.name == 'windows'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,7 +78,7 @@ jobs:
         uses: Minionguyjpro/Inno-Setup-Action@v1.2.2
         with:
           path: packaging/windows/installer.iss
-          options: /DMyAppVersion=${{ env.VERSION }}
+          options: /O"${{ github.workspace }}" /DMyAppVersion=${{ env.VERSION }}
 
       # --- MACOS BUILD ---
       - name: Build macOS

--- a/README.md
+++ b/README.md
@@ -30,6 +30,11 @@ The easiest way to use Immich-Go GUI is to download the pre-built executable for
 
 1. Go to the [Releases page](https://github.com/shitan198u/immich-go-gui/releases/latest).
 
+> **Note on Windows Antivirus Warnings (False Positives):**
+> When downloading the Windows executable, Windows Defender or other antivirus software (like VirusTotal reporting `Trojan:Win32/Wacatac.B!ml` or similar ML-based detections) may flag it as malicious. This is a common **false positive** that occurs because the executable is compiled using Nuitka (a tool that packages Python applications into standalone executables), and antivirus machine-learning heuristics often mistakenly flag packaged software.
+> 
+> You can safely ignore this warning, or if you prefer, you can inspect the source code and run the application manually from source following the instructions below.
+
 ---
 
 ### 💻 Running from Source (Manual)

--- a/README.md
+++ b/README.md
@@ -31,9 +31,9 @@ The easiest way to use Immich-Go GUI is to download the pre-built executable for
 1. Go to the [Releases page](https://github.com/shitan198u/immich-go-gui/releases/latest).
 
 > **Note on Windows Antivirus Warnings (False Positives):**
-> When downloading the Windows executable, Windows Defender or other antivirus software (like VirusTotal reporting `Trojan:Win32/Wacatac.B!ml` or similar ML-based detections) may flag it as malicious. This is a common **false positive** that occurs because the executable is compiled using Nuitka (a tool that packages Python applications into standalone executables), and antivirus machine-learning heuristics often mistakenly flag packaged software.
+> Windows Defender or VirusTotal (e.g., `Trojan:Win32/Wacatac.B!ml`) may flag the executable as malicious. This is a common **false positive** because the app is compiled with Nuitka and lacks a paid Windows digital signature.
 > 
-> You can safely ignore this warning, or if you prefer, you can inspect the source code and run the application manually from source following the instructions below.
+> You can safely ignore this warning or choose to run the application manually from source using the instructions below.
 
 ---
 


### PR DESCRIPTION
## Description
This PR addresses the Windows Defender false positive issue documented in #26. 

We initially added Nuitka metadata to try and resolve the `Trojan:Win32/Wacatac.B!ml` machine learning heuristics detection. While this doesn't completely eliminate the false positive (as bypassing Windows Defender entirely typically requires an EV Authenticode Code Signing Certificate for standalone packages), it does introduce a very nice improvement: **proper `.exe` icon injection and file metadata!**

### Changes Made:
* Added `pillow` to the Windows runner environment to dynamically convert the application `.png` to an `.ico`.
* Injected Nuitka metadata flags (`--windows-icon-from-ico`, `--company-name`, `--file-version`, etc.).
* Ensured the build step correctly uses `shell: bash` to evaluate the regex version extraction on the Windows runner.
* Fixed the Inno Setup action to correctly output the compiled `.exe` installer into the GitHub Actions workspace root so it is successfully uploaded alongside the Portable zip.
* **Architecture Maintained**: Kept the `--standalone` build behavior so that both the `Immich-Go-GUI-Windows-Setup.exe` installer and the portable `.zip` archive are correctly generated.
* **Documentation**: Updated the README.md to concisely explain that the false positive is due to the lack of a paid Windows digital signature.

Closes #26