### PR TITLE
fix: resolve permission denied error on installer builds

### DIFF
--- a/app.py
+++ b/app.py
@@ -158,7 +158,9 @@ class ImmichGoGUI(QMainWindow):
         return None
 
     def update_binary(self):
-        binary_folder = os.path.abspath(os.path.join(os.getcwd(), "immich-go"))
+        # Use user's home directory to ensure write permissions (especially for Windows Program Files installations)
+        user_home = os.path.expanduser("~")
+        binary_folder = os.path.abspath(os.path.join(user_home, ".immich-go-gui", "bin"))
         if not os.path.exists(binary_folder):
             os.makedirs(binary_folder)
 


### PR DESCRIPTION
## Description
This PR resolves a critical bug where the GUI would silently crash when installed via the Windows Setup executable (or system-level packages like `.deb`/`.rpm`).

### The Bug:
Previously, the application used `os.getcwd()` to determine where to create the `immich-go` folder and download the background binary. For applications launched via a shortcut (like in `C:\Program Files`), the working directory defaults to the installation folder. Since standard users do not have write access to `Program Files`, the `os.makedirs()` call would throw a fatal `PermissionError: [WinError 5] Access is denied`, causing the app to crash before the GUI even rendered.

### The Fix:
Changed the download directory path logic to use `os.path.expanduser("~")`. The `immich-go` binary is now correctly downloaded into a hidden folder in the user's home directory (`~/.immich-go-gui/bin/`). 

**Benefits:**
* Guaranteed write permissions across all OS platforms (Windows, macOS, Linux).
* Works flawlessly for installed `.exe` setups, `.deb`, `.rpm`, and AppImages, as they all run under the context of a standard user.
* Keeps the application's installation directory strictly read-only, adhering to security best practices.