### PR TITLE
fix: ensure Nuitka packages SVG icons

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,7 +64,7 @@ jobs:
         run: |
           uv run python -c "from PIL import Image; Image.open('immich-go-gui.png').save('immich-go-gui.ico')"
           NUMERIC_VERSION=$(echo "${{ env.VERSION }}" | grep -oE '^[0-9]+\.[0-9]+\.[0-9]+' || echo "1.0.0")
-          uv run python -m nuitka --assume-yes-for-downloads --standalone --windows-console-mode=disable --enable-plugin=pyside6 --windows-icon-from-ico=immich-go-gui.ico --company-name="Shitan198u" --product-name="Immich-Go GUI" --file-version="${NUMERIC_VERSION}.0" --product-version="${NUMERIC_VERSION}.0" --file-description="Immich-Go Graphical User Interface" --copyright="MIT License" --include-data-files=immich-go-gui.png=immich-go-gui.png --include-data-dir=assets=assets app.py
+          uv run python -m nuitka --file-version="${NUMERIC_VERSION}.0" --product-version="${NUMERIC_VERSION}.0" app.py
 
       - name: Create Windows Portable Archive
         if: matrix.name == 'windows'
@@ -84,7 +84,7 @@ jobs:
       - name: Build macOS
         if: matrix.name == 'macos'
         run: |
-          uv run python -m nuitka --assume-yes-for-downloads --macos-create-app-bundle --enable-plugin=pyside6 --include-data-files=immich-go-gui.png=immich-go-gui.png --include-data-dir=assets=assets app.py
+          uv run python -m nuitka app.py
           npm install -g create-dmg
           create-dmg app.app || true
           mv *.dmg Immich-Go-GUI-macOS.dmg
@@ -93,7 +93,7 @@ jobs:
       - name: Build Linux Standalone
         if: matrix.name == 'linux'
         run: |
-          uv run python -m nuitka --assume-yes-for-downloads --standalone --enable-plugin=pyside6 --include-data-files=immich-go-gui.png=immich-go-gui.png --include-data-dir=assets=assets app.py
+          uv run python -m nuitka app.py
 
       - name: Create Linux Portable Archive
         if: matrix.name == 'linux'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,7 +64,7 @@ jobs:
         run: |
           uv run python -c "from PIL import Image; Image.open('immich-go-gui.png').save('immich-go-gui.ico')"
           NUMERIC_VERSION=$(echo "${{ env.VERSION }}" | grep -oE '^[0-9]+\.[0-9]+\.[0-9]+' || echo "1.0.0")
-          uv run python -m nuitka --assume-yes-for-downloads --standalone --windows-console-mode=disable --enable-plugin=pyside6 --windows-icon-from-ico=immich-go-gui.ico --company-name="Shitan198u" --product-name="Immich-Go GUI" --file-version="${NUMERIC_VERSION}.0" --product-version="${NUMERIC_VERSION}.0" --file-description="Immich-Go Graphical User Interface" --copyright="MIT License" --include-data-files=immich-go-gui.png=immich-go-gui.png app.py
+          uv run python -m nuitka --assume-yes-for-downloads --standalone --windows-console-mode=disable --enable-plugin=pyside6 --windows-icon-from-ico=immich-go-gui.ico --company-name="Shitan198u" --product-name="Immich-Go GUI" --file-version="${NUMERIC_VERSION}.0" --product-version="${NUMERIC_VERSION}.0" --file-description="Immich-Go Graphical User Interface" --copyright="MIT License" --include-data-files=immich-go-gui.png=immich-go-gui.png --include-data-dir=assets=assets app.py
 
       - name: Create Windows Portable Archive
         if: matrix.name == 'windows'
@@ -84,7 +84,7 @@ jobs:
       - name: Build macOS
         if: matrix.name == 'macos'
         run: |
-          uv run python -m nuitka --assume-yes-for-downloads --macos-create-app-bundle --enable-plugin=pyside6 --include-data-files=immich-go-gui.png=immich-go-gui.png app.py
+          uv run python -m nuitka --assume-yes-for-downloads --macos-create-app-bundle --enable-plugin=pyside6 --include-data-files=immich-go-gui.png=immich-go-gui.png --include-data-dir=assets=assets app.py
           npm install -g create-dmg
           create-dmg app.app || true
           mv *.dmg Immich-Go-GUI-macOS.dmg
@@ -93,7 +93,7 @@ jobs:
       - name: Build Linux Standalone
         if: matrix.name == 'linux'
         run: |
-          uv run python -m nuitka --assume-yes-for-downloads --standalone --enable-plugin=pyside6 --include-data-files=immich-go-gui.png=immich-go-gui.png app.py
+          uv run python -m nuitka --assume-yes-for-downloads --standalone --enable-plugin=pyside6 --include-data-files=immich-go-gui.png=immich-go-gui.png --include-data-dir=assets=assets app.py
 
       - name: Create Linux Portable Archive
         if: matrix.name == 'linux'

--- a/app.py
+++ b/app.py
@@ -1,3 +1,23 @@
+# nuitka-project: --assume-yes-for-downloads
+# nuitka-project: --enable-plugin=pyside6
+# nuitka-project: --include-data-files=immich-go-gui.png=immich-go-gui.png
+# nuitka-project: --include-data-dir=assets=assets
+
+# nuitka-project-if: {OS} == "Windows":
+#    nuitka-project: --standalone
+#    nuitka-project: --windows-console-mode=disable
+#    nuitka-project: --windows-icon-from-ico=immich-go-gui.ico
+#    nuitka-project: --company-name="Shitan198u"
+#    nuitka-project: --product-name="Immich-Go GUI"
+#    nuitka-project: --file-description="Immich-Go Graphical User Interface"
+#    nuitka-project: --copyright="MIT License"
+
+# nuitka-project-if: {OS} == "Darwin":
+#    nuitka-project: --macos-create-app-bundle
+
+# nuitka-project-if: {OS} == "Linux":
+#    nuitka-project: --standalone
+
 import sys
 import os
 import re

--- a/uv.lock
+++ b/uv.lock
@@ -115,7 +115,7 @@ wheels = [
 
 [[package]]
 name = "immich-go-gui"
-version = "0.1.0"
+version = "1.0.0"
 source = { virtual = "." }
 dependencies = [
     { name = "psutil" },


### PR DESCRIPTION
## Description
Fixes an issue where the `assets` directory containing SVG icons was excluded from Nuitka builds, resulting in missing icons on all buttons in the packaged binaries.

### Changes
* Centralized all platform-specific Nuitka configuration natively inside `app.py` via `# nuitka-project:` pragmas.
* Added `--include-data-dir=assets=assets` to ensure the icons are bundled into the binary on all platforms.
* Cleaned up `.github/workflows/release.yml` by removing all redundant Nuitka CLI arguments.