### PR TITLE
fix: pre-release hardening (pause-jobs, SHA256, CLI defaults)

### DIFF
--- a/app.py
+++ b/app.py
@@ -536,9 +536,6 @@ class ImmichGoGUI(QMainWindow):
         "stack",
     ]
 
-    # FIX Phase 2 #11/#12: define upload-only tab set for flag scoping
-    UPLOAD_TABS = {"upload-folder", "upload-gp", "upload-immich"}
-
     def __init__(self):
         super().__init__()
         self.setWindowTitle("Immich Go GUI")

--- a/core/binary_manager.py
+++ b/core/binary_manager.py
@@ -448,8 +448,8 @@ class BinaryManager:
             current_version=current_clean,
         )
 
-    def get_release_asset_url(self, version: str) -> str | None:
-        """Fetch release metadata from GitHub API and discover asset URL for current OS/arch."""
+    def _fetch_release_json(self, version: str) -> dict | None:
+        """Fetch GitHub release metadata JSON for a version tag."""
         clean_v = clean_version(version)
         if not clean_v:
             return None
@@ -458,6 +458,62 @@ class BinaryManager:
             f"https://api.github.com/repos/simulot/immich-go/releases/tags/v{clean_v}",
             f"https://api.github.com/repos/simulot/immich-go/releases/tags/{clean_v}",
         ]
+        for u in urls:
+            try:
+                res = requests.get(u, timeout=10)
+                if res.status_code == 200:
+                    return res.json()
+            except Exception:
+                pass
+        return None
+
+    def get_checksums_url(self, version: str) -> str | None:
+        """Return browser_download_url for checksums.txt on a GitHub release."""
+        data = self._fetch_release_json(version)
+        if not data:
+            return None
+        for asset in data.get("assets", []):
+            name = asset.get("name", "")
+            if name.lower() == "checksums.txt":
+                return asset.get("browser_download_url", "") or None
+        return None
+
+    def fetch_checksums(self, version: str) -> dict[str, str]:
+        """Fetch and parse checksums.txt for a release version."""
+        url = self.get_checksums_url(version)
+        if not url:
+            return {}
+        try:
+            res = requests.get(url, timeout=15)
+            res.raise_for_status()
+            checksums: dict[str, str] = {}
+            for line in res.text.splitlines():
+                line = line.strip()
+                if not line or line.startswith("#"):
+                    continue
+                parts = line.split()
+                if len(parts) >= 2:
+                    checksums[parts[-1]] = parts[0]
+            return checksums
+        except Exception:
+            return {}
+
+    def verify_archive_checksum(self, archive_path: str, expected_hash: str) -> bool:
+        """Verify SHA256 of an archive file against an expected hex digest."""
+        if not expected_hash:
+            return False
+        try:
+            with open(archive_path, "rb") as f:
+                actual = calculate_sha256(f.read())
+        except OSError:
+            return False
+        return actual.lower() == expected_hash.lower()
+
+    def get_release_asset_url(self, version: str) -> str | None:
+        """Fetch release metadata from GitHub API and discover asset URL for current OS/arch."""
+        clean_v = clean_version(version)
+        if not clean_v:
+            return None
 
         if self.os_name.startswith("win"):
             target_os = "windows"
@@ -479,19 +535,13 @@ class BinaryManager:
         }
         target_arch = arch_map.get(self.arch, "x86_64")
 
-        for u in urls:
-            try:
-                res = requests.get(u, timeout=10)
-                if res.status_code == 200:
-                    data = res.json()
-                    assets = data.get("assets", [])
-                    for asset in assets:
-                        name = asset.get("name", "").lower()
-                        download_url = asset.get("browser_download_url", "")
-                        if target_os in name and target_arch in name and name.endswith(ext) and download_url:
-                            return download_url
-            except Exception:
-                pass
+        data = self._fetch_release_json(clean_v)
+        if data:
+            for asset in data.get("assets", []):
+                name = asset.get("name", "").lower()
+                download_url = asset.get("browser_download_url", "")
+                if target_os in name and target_arch in name and name.endswith(ext) and download_url:
+                    return download_url
 
         return self.get_download_url(version)
 
@@ -558,6 +608,21 @@ class BinaryManager:
                         f.write(chunk)
                         if total > 0 and progress_cb:
                             progress_cb(int(downloaded * 100 / total))
+
+            archive_name = os.path.basename(url.split("?")[0])
+            checksums = self.fetch_checksums(clean_v)
+            if not checksums:
+                return False, "Release checksums.txt not found — install aborted for safety"
+
+            expected_hash = checksums.get(archive_name)
+            if not expected_hash:
+                return (
+                    False,
+                    f"No checksum entry for {archive_name} in checksums.txt — install aborted",
+                )
+
+            if not self.verify_archive_checksum(temp_archive, expected_hash):
+                return False, "Archive checksum verification failed — install aborted"
 
             if url.endswith(".zip"):
                 with zipfile.ZipFile(temp_archive) as z:

--- a/core/cli_contract.py
+++ b/core/cli_contract.py
@@ -8,7 +8,12 @@ from pathlib import Path
 import subprocess
 
 from .binary_manager import TESTED_IMMICH_GO_VERSION
-from .cli_help import load_help_fixture, parse_help_flags, help_name_for_tab
+from .cli_help import (
+    load_help_fixture,
+    parse_help_bool_defaults,
+    parse_help_flags,
+    help_name_for_tab,
+)
 from .cli_schema import TAB_ALLOWED_FLAGS, TAB_KEYS, COMPATIBILITY_MATRIX
 
 
@@ -58,27 +63,42 @@ def check_fixtures(version: str = TESTED_IMMICH_GO_VERSION) -> CompatibilityRepo
     return report
 
 
+_TAB_SUBCOMMANDS: dict[str, list[str]] = {
+    "upload-folder": ["upload", "from-folder"],
+    "upload-gp": ["upload", "from-google-photos"],
+    "upload-icloud": ["upload", "from-icloud"],
+    "upload-picasa": ["upload", "from-picasa"],
+    "upload-immich": ["upload", "from-immich"],
+    "archive-folder": ["archive", "from-folder"],
+    "archive-gp": ["archive", "from-google-photos"],
+    "archive-icloud": ["archive", "from-icloud"],
+    "archive-picasa": ["archive", "from-picasa"],
+    "archive-immich": ["archive", "from-immich"],
+    "stack": ["stack"],
+}
+
+
+def collect_bool_defaults_from_binary(binary_path: Path) -> dict[str, dict[str, bool]]:
+    """Run --help on each tab subcommand and parse bool flag defaults."""
+    result: dict[str, dict[str, bool]] = {}
+    for tab_key, args in _TAB_SUBCOMMANDS.items():
+        cmd = [str(binary_path)] + args + ["--help"]
+        try:
+            res = subprocess.run(cmd, capture_output=True, text=True, timeout=5)
+            text = res.stdout if res.stdout else res.stderr
+            result[tab_key] = parse_help_bool_defaults(text)
+        except Exception:
+            result[tab_key] = {}
+    return result
+
+
 def check_binary_help(binary_path: Path, version: str = TESTED_IMMICH_GO_VERSION) -> CompatibilityReport:
     """Runs --help on target subcommands of live binary and compares against GUI allowlists."""
     report = CompatibilityReport(version=version)
     matrix_entry = COMPATIBILITY_MATRIX.get(version, {})
     report.notes = matrix_entry.get("notes", "")
 
-    subcommands = {
-        "upload-folder": ["upload", "from-folder"],
-        "upload-gp": ["upload", "from-google-photos"],
-        "upload-icloud": ["upload", "from-icloud"],
-        "upload-picasa": ["upload", "from-picasa"],
-        "upload-immich": ["upload", "from-immich"],
-        "archive-folder": ["archive", "from-folder"],
-        "archive-gp": ["archive", "from-google-photos"],
-        "archive-icloud": ["archive", "from-icloud"],
-        "archive-picasa": ["archive", "from-picasa"],
-        "archive-immich": ["archive", "from-immich"],
-        "stack": ["stack"],
-    }
-
-    for tab_key, args in subcommands.items():
+    for tab_key, args in _TAB_SUBCOMMANDS.items():
         gui_allowed = TAB_ALLOWED_FLAGS.get(tab_key, set())
         cmd = [str(binary_path)] + args + ["--help"]
         try:

--- a/core/cli_help.py
+++ b/core/cli_help.py
@@ -7,6 +7,10 @@ from pathlib import Path
 import re
 
 _FLAG_PATTERN = re.compile(r"(?:^|\s)--([a-zA-Z0-9-]+)(?:[=[\s]|$)")
+_BOOL_DEFAULT_PATTERN = re.compile(
+    r"--([a-zA-Z0-9-]+).*?\(default (true|false)\)",
+    re.IGNORECASE,
+)
 
 
 def parse_help_flags(help_text: str) -> set[str]:
@@ -22,6 +26,19 @@ def parse_help_flags(help_text: str) -> set[str]:
             if flag and flag != "help":
                 flags.add(flag)
     return flags
+
+
+def parse_help_bool_defaults(help_text: str) -> dict[str, bool]:
+    """Extract bool flag defaults from immich-go CLI --help text.
+
+    Parses lines like ``--recursive  Scan subdirectories (default true)``.
+  """
+    defaults: dict[str, bool] = {}
+    for line in help_text.splitlines():
+        match = _BOOL_DEFAULT_PATTERN.search(line)
+        if match:
+            defaults[match.group(1)] = match.group(2).lower() == "true"
+    return defaults
 
 
 def help_name_for_tab(tab_key: str) -> str:

--- a/core/command_builder.py
+++ b/core/command_builder.py
@@ -561,7 +561,10 @@ def build_plan_from_state(
 
     # ── 6. Safety: pause-jobs without admin key ────────────────
     if tab_key in UPLOAD_TABS or tab_key == "stack":
-        has_pause = any("pause-immich-jobs" in o for o in emitter.opts)
+        has_pause = any(
+            emitter._flag_name_from_arg(o) == "pause-immich-jobs"
+            for o in emitter.opts
+        )
         if not has_pause and not admin_api_key:
             emitter.add_bool_val("pause-immich-jobs", False, source="safety")
             plan.warnings.append(

--- a/core/flags.toml
+++ b/core/flags.toml
@@ -923,7 +923,7 @@ kind = "bool"
 default = false
 mode = "advanced"
 # ── upload-picasa (31 flags) ──────────────────────────────────
-# Fix §1.1: folder-album and into-album are mode="both"
+# upload-picasa: folder-album and into-album are mode="simple" (see below)
 
 [[flags.upload-picasa]]
 key = "path"
@@ -1030,7 +1030,7 @@ key = "album-picasa"
 flag = "album-picasa"
 label = "Use Picasa album name found in .picasa.ini file"
 kind = "bool"
-default = false
+default = true
 mode = "advanced"
 
 [[flags.upload-picasa]]
@@ -2055,7 +2055,7 @@ key = "album-picasa"
 flag = "album-picasa"
 label = "Use Picasa album name found in .picasa.ini file"
 kind = "bool"
-default = false
+default = true
 mode = "advanced"
 
 [[flags.archive-picasa]]

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1330,7 +1330,8 @@ def test_load_help_fixture():
 
 
 def test_all_tab_allowed_flags_exist_in_help_fixtures():
-    tabs = ["upload-folder", "upload-gp", "upload-immich", "archive-folder", "archive-immich", "stack"]
+    from core.flag_registry import REGISTRY
+    tabs = list(REGISTRY.tabs.keys())
     for tab_key in tabs:
         fixture_name = help_name_for_tab(tab_key)
         fixture_flags = load_help_fixture("0.32.0", fixture_name)
@@ -1546,7 +1547,8 @@ def test_windows_stale_lock_on_closed_terminal(tmp_path, monkeypatch):
     seeing terminal_pid dead, and the fresh heartbeat file returned True forever.
     """
     monkeypatch.setenv("IMMICH_GO_GUI_CONFIG", str(tmp_path / "config.toml"))
-    monkeypatch.setattr("sys.platform", "win32")
+    monkeypatch.setattr("core.process_tracker.sys.platform", "win32")
+    monkeypatch.setattr("core.process_tracker._is_process_alive", lambda pid: False)
     from core.process_tracker import create_lock, update_lock, is_lock_active, release_lock
 
     l_path = create_lock("upload-folder", "upload", "./immich-go")
@@ -1572,6 +1574,36 @@ def test_windows_stale_lock_on_closed_terminal(tmp_path, monkeypatch):
     )
 
     release_lock(l_path)
+
+
+def test_is_process_alive_win32_still_active(monkeypatch):
+    """Cover win32 ctypes OpenProcess / GetExitCodeProcess path in _is_process_alive."""
+    monkeypatch.setattr("core.process_tracker.sys.platform", "win32")
+
+    class FakeKernel32:
+        STILL_ACTIVE = 259
+
+        def OpenProcess(self, access, inherit, pid):
+            return 42 if pid == 1234 else 0
+
+        def GetExitCodeProcess(self, handle, exit_code_ref):
+            exit_code_ref._obj.value = self.STILL_ACTIVE
+            return 1
+
+        def CloseHandle(self, handle):
+            return 1
+
+    fake_kernel32 = FakeKernel32()
+    import ctypes
+    fake_windll = type("windll", (), {})()
+    fake_windll.kernel32 = fake_kernel32
+    monkeypatch.setattr(ctypes, "windll", fake_windll, raising=False)
+
+    from core.process_tracker import _is_process_alive
+
+    assert _is_process_alive(1234) is True
+    assert _is_process_alive(9999) is False
+    assert _is_process_alive(None) is False
 
 
 def test_forward_all_immich_go_env_vars(tmp_path, monkeypatch):
@@ -2310,6 +2342,112 @@ def test_binary_manager_download_and_install_cancellation(tmp_path):
     assert not (v_dir / "immich-go.tmp").exists()
 
 
+def _make_tar_gz_archive(content: bytes = b"#!/bin/sh\necho 0.32.0\n") -> bytes:
+    import io
+    import tarfile
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+        data = content
+        info = tarfile.TarInfo(name="immich-go")
+        info.size = len(data)
+        info.mode = 0o755
+        tar.addfile(info, io.BytesIO(data))
+    return buf.getvalue()
+
+
+def test_binary_manager_checksum_verification_pass(tmp_path):
+    from core.binary_manager import BinaryManager, calculate_sha256
+
+    archive_bytes = _make_tar_gz_archive()
+    archive_name = "immich-go_0.32.0_linux_x86_64.tar.gz"
+    url = f"https://example.com/{archive_name}"
+    checksums = {archive_name: calculate_sha256(archive_bytes)}
+
+    bm = BinaryManager(base_dir=str(tmp_path), os_name="linux", arch="x86_64")
+
+    mock_res = MagicMock()
+    mock_res.headers = {"content-length": str(len(archive_bytes))}
+    mock_res.iter_content.return_value = [archive_bytes]
+    mock_res.__enter__.return_value = mock_res
+
+    with patch.object(bm, "get_release_asset_url", return_value=url), \
+         patch.object(bm, "fetch_checksums", return_value=checksums), \
+         patch("requests.get", return_value=mock_res), \
+         patch.object(bm, "verify_extracted_binary", return_value=True):
+        success, msg = bm.download_and_install(version="0.32.0")
+        assert success is True
+        assert "Successfully installed" in msg
+
+
+def test_binary_manager_checksum_verification_fail(tmp_path):
+    from core.binary_manager import BinaryManager, calculate_sha256
+
+    archive_bytes = _make_tar_gz_archive()
+    archive_name = "immich-go_0.32.0_linux_x86_64.tar.gz"
+    url = f"https://example.com/{archive_name}"
+    checksums = {archive_name: "0000000000000000000000000000000000000000000000000000000000000000"}
+
+    bm = BinaryManager(base_dir=str(tmp_path), os_name="linux", arch="x86_64")
+
+    mock_res = MagicMock()
+    mock_res.headers = {"content-length": str(len(archive_bytes))}
+    mock_res.iter_content.return_value = [archive_bytes]
+    mock_res.__enter__.return_value = mock_res
+
+    with patch.object(bm, "get_release_asset_url", return_value=url), \
+         patch.object(bm, "fetch_checksums", return_value=checksums), \
+         patch("requests.get", return_value=mock_res):
+        success, msg = bm.download_and_install(version="0.32.0")
+        assert success is False
+        assert "checksum verification failed" in msg.lower()
+
+
+def test_binary_manager_checksum_missing_checksums_txt(tmp_path):
+    from core.binary_manager import BinaryManager, calculate_sha256
+
+    archive_bytes = _make_tar_gz_archive()
+    archive_name = "immich-go_0.32.0_linux_x86_64.tar.gz"
+    url = f"https://example.com/{archive_name}"
+
+    bm = BinaryManager(base_dir=str(tmp_path), os_name="linux", arch="x86_64")
+
+    mock_res = MagicMock()
+    mock_res.headers = {"content-length": str(len(archive_bytes))}
+    mock_res.iter_content.return_value = [archive_bytes]
+    mock_res.__enter__.return_value = mock_res
+
+    with patch.object(bm, "get_release_asset_url", return_value=url), \
+         patch.object(bm, "fetch_checksums", return_value={}), \
+         patch("requests.get", return_value=mock_res):
+        success, msg = bm.download_and_install(version="0.32.0")
+        assert success is False
+        assert "checksums.txt" in msg.lower()
+
+
+def test_binary_manager_checksum_tampered_archive(tmp_path):
+    from core.binary_manager import BinaryManager, calculate_sha256
+
+    good_bytes = _make_tar_gz_archive(b"good binary")
+    tampered_bytes = _make_tar_gz_archive(b"tampered binary")
+    archive_name = "immich-go_0.32.0_linux_x86_64.tar.gz"
+    url = f"https://example.com/{archive_name}"
+    checksums = {archive_name: calculate_sha256(good_bytes)}
+
+    bm = BinaryManager(base_dir=str(tmp_path), os_name="linux", arch="x86_64")
+
+    mock_res = MagicMock()
+    mock_res.headers = {"content-length": str(len(tampered_bytes))}
+    mock_res.iter_content.return_value = [tampered_bytes]
+    mock_res.__enter__.return_value = mock_res
+
+    with patch.object(bm, "get_release_asset_url", return_value=url), \
+         patch.object(bm, "fetch_checksums", return_value=checksums), \
+         patch("requests.get", return_value=mock_res):
+        success, msg = bm.download_and_install(version="0.32.0")
+        assert success is False
+        assert "checksum verification failed" in msg.lower()
+
+
 def test_windows_bat_heartbeat_generation(tmp_path, monkeypatch):
     """Fix 1.4: Windows terminal launch generates a .bat file with background heartbeat loop."""
     from core.terminal_launcher import launch_external_terminal
@@ -2678,6 +2816,12 @@ class TestBinaryManagerWindowsPathResolution:
 from core.command_builder import build_plan_from_state as _build_plan
 
 
+def _pause_flag_args(argv):
+    from core.command_builder import FlagEmitter
+    emitter = FlagEmitter("upload-folder")
+    return [a for a in argv if emitter._flag_name_from_arg(a) == "pause-immich-jobs"]
+
+
 class TestPauseJobsAutoDisable:
     """Regression tests for Bug #64: --pause-immich-jobs + no admin key = 403."""
 
@@ -2723,7 +2867,7 @@ class TestPauseJobsAutoDisable:
             advanced_state={"pause-jobs": {"enabled": True, "value": False}},
             binary_path="./immich-go",
         )
-        pause_flags = [a for a in plan.argv if "pause-immich-jobs" in a]
+        pause_flags = _pause_flag_args(plan.argv)
         assert len(pause_flags) == 1, f"Expected exactly one pause flag; got: {pause_flags}"
         assert pause_flags[0] == "--pause-immich-jobs=false"
         # No warning because user explicitly disabled it
@@ -2765,6 +2909,17 @@ class TestPauseJobsAutoDisable:
                 f"Expected auto-disable on tab '{tab_key}'; argv={plan.argv}"
             )
 
+    def test_from_pause_does_not_suppress_dest_pause_safety(self):
+        """from-pause-immich-jobs must not block destination pause safety injection."""
+        plan = _build_plan(
+            tab_key="upload-immich",
+            config_state={**self._BASE_CONFIG, "admin_api_key": ""},
+            tab_state={"from-server": "http://old:2283", "from-api-key": "old-key"},
+            advanced_state={"from-pause-jobs": {"enabled": True, "value": True}},
+            binary_path="./immich-go",
+        )
+        assert "--pause-immich-jobs=false" in plan.argv
+
     def test_no_double_pause_flag_injection(self):
         """When admin key is absent AND pause=False via advanced row, only one flag is emitted."""
         plan = _build_plan(
@@ -2774,8 +2929,9 @@ class TestPauseJobsAutoDisable:
             advanced_state={"pause-jobs": {"enabled": True, "value": False}},
             binary_path="./immich-go",
         )
-        pause_flags = [a for a in plan.argv if "pause-immich-jobs" in a]
+        pause_flags = _pause_flag_args(plan.argv)
         assert len(pause_flags) == 1, f"Expected exactly one pause flag; got: {pause_flags}"
+
 
 # ==============================================================================
 # Phase 2–6 hardening coverage

--- a/tests/test_emission_model.py
+++ b/tests/test_emission_model.py
@@ -75,7 +75,11 @@ def test_advanced_mode_pause_jobs_row_emits(gui):
     gui.inputs["upload-folder"]["path"].setText("/photos")
     gui.adv_rows["upload-folder"]["pause-jobs"].set_state({"enabled": True, "value": True})
     opts = gui.build_command(dry_run=False)
-    assert any("--pause-immich-jobs" in o for o in opts)
+    from core.command_builder import FlagEmitter
+    emitter = FlagEmitter("upload-folder")
+    assert any(
+        emitter._flag_name_from_arg(o) == "pause-immich-jobs" for o in opts
+    )
 
 
 def test_advanced_mode_picasa_folder_album_emitted(gui):

--- a/tests/test_flag_registry.py
+++ b/tests/test_flag_registry.py
@@ -1,4 +1,6 @@
 """Tests for unified flag registry (core/flags.toml and core/flag_registry.py)."""
+import pytest
+
 from core.flag_registry import REGISTRY
 
 
@@ -64,3 +66,52 @@ def test_picasa_simple_keys_are_not_advanced_only():
     assert "folder-album" not in REGISTRY.advanced_keys("upload-picasa")
     assert "into-album" not in REGISTRY.advanced_keys("upload-picasa")
     assert "recursive" in REGISTRY.advanced_keys("upload-picasa")
+
+
+def test_bool_defaults_match_live_cli():
+    """Bool flag defaults in flags.toml must match live immich-go --help output."""
+    import subprocess
+    from pathlib import Path
+
+    from core.binary_manager import (
+        get_binary_path,
+        load_binary_metadata,
+        parse_version_output,
+        TESTED_IMMICH_GO_VERSION,
+    )
+    from core.cli_contract import collect_bool_defaults_from_binary
+
+    meta = load_binary_metadata()
+    binary_path = get_binary_path(meta)
+    if not binary_path or not Path(binary_path).exists():
+        pytest.skip("immich-go binary not installed")
+
+    try:
+        res = subprocess.run(
+            [binary_path, "version"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        version = parse_version_output(res.stdout or res.stderr)
+    except Exception:
+        pytest.skip("immich-go binary not runnable")
+
+    if version != TESTED_IMMICH_GO_VERSION:
+        pytest.skip(
+            f"immich-go version {version} != tested version {TESTED_IMMICH_GO_VERSION}"
+        )
+
+    cli_defaults = collect_bool_defaults_from_binary(Path(binary_path))
+
+    for tab_key, flag_defs in REGISTRY.flags.items():
+        tab_defaults = cli_defaults.get(tab_key, {})
+        for flag_def in flag_defs:
+            if flag_def.kind != "bool" or not flag_def.flag:
+                continue
+            if flag_def.flag not in tab_defaults:
+                continue
+            assert flag_def.default == tab_defaults[flag_def.flag], (
+                f"Tab {tab_key}: flag {flag_def.flag} default "
+                f"{flag_def.default!r} != CLI {tab_defaults[flag_def.flag]!r}"
+            )


### PR DESCRIPTION
## Summary
- Fix pause-jobs safety check substring collision (`from-pause-immich-jobs` no longer suppresses destination `--pause-immich-jobs=false`)
- Correct `album-picasa` TOML defaults; add live CLI bool-default cross-check
- Implement real SHA256 archive verification via `checksums.txt` before install
- Remove dead `UPLOAD_TABS` class attribute; harden Windows lock tests

## Test plan
- [x] `TestPauseJobsAutoDisable`, checksum, and Windows lock tests
- [x] 205 tests pass when stacked through final branch

**Stacks on:** #TBD flags PR

Made with [Cursor](https://cursor.com)