### PR TITLE
docs: align guides with flags.toml emission model

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -20,7 +20,7 @@
   - **Archive**: `archive-folder`, `archive-gp`, `archive-icloud`, `archive-picasa`, `archive-immich`
   - **Stack**: `stack`
 - **Serverless Tab Rule**: `archive-folder`, `archive-gp`, `archive-icloud`, and `archive-picasa` are strictly classified as `SERVERLESS_TABS`. They must NEVER emit `--server`, `--api-key`, or `--client-timeout` flags.
-- **Simple vs. Advanced Control Policy**: Simple mode shows high-frequency inputs only. Advanced mode dynamically generates flag rows from `ADVANCED_FLAGS` in `core/advanced_flags.py`.
+- **Simple vs. Advanced Control Policy**: Simple mode shows high-frequency inputs only. Advanced mode dynamically generates flag rows from `core/flags.toml` via `core/flag_registry.py` (`mode = "simple"` or `mode = "advanced"`).
 
 ## 4. Security & Secret Isolation
 - **In-Memory Secret Delivery**: Sensitive API keys (`IMMICH_GO_UPLOAD_API_KEY`, `IMMICH_GO_UPLOAD_FROM_IMMICH_FROM_API_KEY`, etc.) are passed strictly through process memory environment dictionaries (`posix_env` / `win_env`) in `subprocess.Popen`. NEVER write secret environment variables or credentials to disk shell scripts (such as `env.sh`).
@@ -45,3 +45,83 @@
 - **Release Please Config Location**: Configuration files belong in `.github/release-please-config.json` and `.github/.release-please-manifest.json`.
 - **Release Please Manifest Sync**: `.github/.release-please-manifest.json` must be explicitly updated whenever performing manual version bumps or hotfix releases so Release Please tracks the correct baseline version.
 
+
+
+# Immich-Go GUI — Project Context Brief
+
+## What It Is
+
+A **PySide6 desktop GUI** wrapping the [immich-go](https://github.com/simulot/immich-go) CLI (v0.32.0). Users configure upload/archive/stack jobs via forms, preview the exact CLI command, and launch it in an external terminal. **11 workflow tabs** cover every immich-go subcommand.
+
+## Architecture (Non-Negotiable Rules)
+
+- **`core/` is Qt-free.** All business logic, testable headlessly.
+- **Secrets never go in argv.** API keys travel via environment variables (`IMMICH_GO_*`), stored in OS keyring.
+- **Serverless archive tabs** (`archive-folder`, `archive-gp`, `archive-icloud`, `archive-picasa`) must **never** emit `--server`, `--api-key`, or `--client-timeout`.
+- **`core/flags.toml`** is the single source of truth for all flag definitions, loaded by `core/flag_registry.py`. `cli_schema.py` and `advanced_flags.py` are thin delegation shims.
+
+## Key Files
+
+| File | Role |
+|---|---|
+| `app.py` (~3575 lines) | Qt UI: tabs, widgets, events, run/save/load |
+| `theme.py` | Theming, palettes, SVG icons |
+| `core/flags.toml` (~2809 lines) | **Single source of truth** for all tabs + flags |
+| `core/flag_registry.py` | Loads flags.toml → `REGISTRY` singleton |
+| `core/command_builder.py` | `build_plan_from_state()` → `CommandPlan` (argv + env) |
+| `core/advanced_flags.py` | `advanced_flag_args()`, `apply_advanced_flags_to_plan()` |
+| `core/cli_schema.py` | Re-exports from registry (TAB_COMMANDS, TAB_ALLOWED_FLAGS, etc.) |
+| `core/config_manager.py` | TOML config + keyring secrets |
+| `core/binary_manager.py` | immich-go download/verify/version |
+| `core/terminal_launcher.py` | Cross-platform external terminal launch |
+| `core/process_tracker.py` | Run lock files |
+| `tests/test_app.py` (~3151 lines) | Main test suite |
+| `tests/test_flag_registry.py` | Registry validation tests |
+| `tests/test_emission_model.py` | Emission model tests |
+
+## Current Flag Model (1.4.0 emission model)
+
+Implemented in 1.4.0. The `emission` field was removed from `flags.toml`.
+
+### The One Rule
+> **A flag reaches the CLI if and only if the user explicitly asked for it.** immich-go applies its own defaults for anything not passed.
+
+### Model
+- **`mode` is the only behavioral field:** `simple` | `advanced`
+- **Simple mode:** Only `mode=simple` widgets visible. Emit if value ≠ TOML/CLI default.
+- **Advanced mode:** Advanced rows shown, **all disabled by default**. Emit **only** if user checks the enable box. Row value pre-populated from saved config (takes precedence) or CLI default.
+- **Config tab:** server URL, API key, admin key, skip-SSL, secret provider, theme, binary mgmt, allow-untested, preferred-terminal. No per-flag widgets for `client-timeout`, `concurrent-tasks`, `device-uuid`, `on-errors`, or `pause-immich-jobs` — those are per-tab advanced rows.
+- **pause-jobs safety:** Post-check after all flags emitted — if upload/stack tab + no admin key + no explicit pause flag in argv → emit `--pause-immich-jobs=false` + warning (`source="safety"` in emission log).
+
+### Config Persistence for Advanced Rows
+- **Values persist** in `form_state.advanced.{tab}.{key}.value`
+- **Enabled state persists** in `form_state.advanced.{tab}.{key}.enabled`
+- On fresh install / "Reset Advanced Flags": all disabled, values = CLI defaults
+- Saved config value takes precedence over flags.toml default for **display only**. Emission still requires the checkbox.
+
+### Emission Logic
+1. Structural flags (server, skip-ssl, dry-run) — always when applicable
+2. Simple widgets — emit if value ≠ default
+3. Advanced rows — emit ONLY if enabled
+4. Positional args (paths)
+5. Safety post-check (pause-jobs)
+
+## Tech Stack
+
+- Python 3.13 (`>=3.13.0, <3.14`), PySide6, `uv` package manager
+- TOML config (`tomllib`/`tomli` + `tomli_w`), `keyring`, `requests`, `packaging`
+- pytest + pytest-qt, Nuitka for release builds
+- MkDocs Material for docs site
+
+## Branching & Releases
+
+- PRs target **`staging`**, never `master` directly.
+- Release Please with Conventional Commits.
+- Multi-platform builds: Windows (exe/zip), macOS (dmg), Linux (AppImage/deb/rpm/tar).
+
+## Testing Conventions
+
+- `_norm_argv()` for all path comparisons in argv assertions.
+- Golden JSON fixtures in `tests/fixtures/command_states/`.
+- CLI help fixtures in `tests/fixtures/cli_help/0.32.0/`.
+- Run: `uv run pytest` (Linux headless: `QT_QPA_PLATFORM=offscreen xvfb-run uv run pytest`).

--- a/docs/developer-guide/architecture.md
+++ b/docs/developer-guide/architecture.md
@@ -59,9 +59,11 @@ immich-go-gui/
 ├── app.py                 # Qt UI: tabs, widgets, run/save/load orchestration
 ├── theme.py               # Theming: Fusion style, palettes, SVG icons
 ├── core/                  # Qt-free business logic (testable without GUI)
+│   ├── flags.toml         # Single source of truth for tabs + flags
+│   ├── flag_registry.py   # Loads flags.toml → REGISTRY singleton
 │   ├── models.py          # Dataclasses / enums
-│   ├── cli_schema.py      # Tab keys, allowlists, env maps
-│   ├── advanced_flags.py  # Advanced flag registry
+│   ├── cli_schema.py      # Thin shim: TAB_COMMANDS, TAB_ALLOWED_FLAGS, etc.
+│   ├── advanced_flags.py  # Thin shim over registry advanced defs
 │   ├── command_builder.py # state dict produces a CommandPlan
 │   ├── config_manager.py  # TOML + keyring secrets
 │   ├── profile_manager.py # Multi-profile index
@@ -146,7 +148,7 @@ The GUI maintains **11/11 parity** with immich-go subcommands:
 - 5 archive tabs
 - 1 stack tab
 
-Each tab maps to a fixed command token list in `core/cli_schema.py` (`TAB_COMMANDS`). Allowed flags per tab are defined in `TAB_ALLOWED_FLAGS` and validated at build time.
+Each tab maps to a fixed command token list in `core/cli_schema.py` (`TAB_COMMANDS`). Allowed flags per tab are defined in `core/flags.toml` and loaded via `core/flag_registry.py` (`TAB_ALLOWED_FLAGS` is a shim export). Validated at build time.
 
 ### Serverless Tab Rule
 

--- a/docs/developer-guide/core-modules.md
+++ b/docs/developer-guide/core-modules.md
@@ -114,7 +114,7 @@ immich-go binary lifecycle.
 | `TESTED_IMMICH_GO_VERSIONS` | Frozenset of tested versions |
 | `BinaryManager` | Download, verify, update binary |
 | `get_version_support()` | Classify version compatibility |
-| `BINARY_BASE_DIR` | `~/.immich-go-gui/bin/` |
+| `BINARY_BASE_DIR` | `~/.immich-go-gui/bin/` (versioned subdirs: `bin/{version}/immich-go`) |
 
 Downloads from GitHub Releases with SHA256 verification.
 

--- a/docs/developer-guide/testing.md
+++ b/docs/developer-guide/testing.md
@@ -1,6 +1,6 @@
 # Testing
 
-The test suite lives in `tests/test_app.py` (~100 tests) using pytest and pytest-qt.
+The test suite lives in `tests/test_app.py` (205 tests) using pytest and pytest-qt.
 
 ## Running Tests
 
@@ -92,14 +92,14 @@ Fixtures are stored in `tests/fixtures/cli_help/{version}/`.
 
 When immich-go releases a new version:
 
-1. Install or download the new binary to `~/.immich-go-gui/bin/`
+1. Install or download the new binary to `~/.immich-go-gui/bin/{version}/`
 2. Run the capture script:
 
 ```bash
 uv run scripts/capture_cli_help.py
 ```
 
-3. Update `TAB_ALLOWED_FLAGS` in `core/cli_schema.py` if flags changed
+3. Update `core/flags.toml` if flags changed
 4. Run tests and fix any golden fixture drift
 
 See [Scripts](scripts.md) for script details.

--- a/docs/reference/immich-go-compatibility.md
+++ b/docs/reference/immich-go-compatibility.md
@@ -38,16 +38,23 @@ From `VERSION_NOTES` and `COMPATIBILITY_MATRIX`:
 
 | Path | Purpose |
 |------|---------|
-| `~/.immich-go-gui/bin/` | Downloaded binary |
-| `~/.immich-go-gui/bin/metadata.json` | Version, download date, SHA256 |
+| `~/.immich-go-gui/bin/` | Base directory for all installed versions |
+| `~/.immich-go-gui/bin/{version}/immich-go` | Versioned binary (`.exe` on Windows) |
+| `~/.immich-go-gui/bin/metadata.json` | `selected_version`, per-version records, optional `manual_path` |
+
+Legacy flat installs (`~/.immich-go-gui/bin/immich-go` without a version subdirectory) are still resolved as a fallback.
 
 ### Download Process
 
+Triggered from the Config tab (or a pre-run download prompt), not on every launch:
+
 1. GUI queries [GitHub Releases](https://github.com/simulot/immich-go/releases) for the target version
-2. Downloads platform-appropriate archive (`.tar.gz` or `.zip`)
-3. Verifies SHA256 checksum
-4. Extracts binary to `~/.immich-go-gui/bin/`
-5. Updates `metadata.json`
+2. Downloads platform-appropriate archive (`.tar.gz` or `.zip`) to a temp file inside `bin/{version}/`
+3. Fetches `checksums.txt` from the same release — **install aborts if missing** (fail-closed)
+4. Verifies archive SHA256 against the entry for the downloaded archive name
+5. Extracts binary to `~/.immich-go-gui/bin/{version}/immich-go`
+6. Runs post-extract verification (`immich-go version`) — install aborts if the binary is unusable
+7. Updates `metadata.json` and sets `selected_version`
 
 ### Version Detection
 
@@ -61,16 +68,16 @@ From the Config tab:
 2. Click download/update if a newer recommended version is available
 3. Review compatibility warnings before proceeding
 
-For manual updates, place the binary in `~/.immich-go-gui/bin/` and update `metadata.json`.
+For manual updates, place the binary in `~/.immich-go-gui/bin/{version}/` and update `metadata.json` (or set `manual_path`).
 
 ## CLI Fixture Workflow
 
 When immich-go releases a new version, maintainers should:
 
-1. Download the new binary
+1. Download the new binary (or use Config tab download)
 2. Run `uv run scripts/capture_cli_help.py`
-3. Update `TAB_ALLOWED_FLAGS` for any flag changes
-4. Update version constants in `binary_manager.py` and `cli_schema.py`
+3. Edit `core/flags.toml` for any flag changes
+4. Update version constants in `binary_manager.py` only
 5. Run full test suite: `uv run pytest`
 6. Update `CHANGELOG.md` and this document
 

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -9,7 +9,7 @@ The **Config** tab holds global settings shared across workflow tabs: Immich ser
 | **Server URL** | Base URL of your Immich instance (e.g. `https://immich.local`). Used by upload tabs, Stack, and Archive from Immich. |
 | **Skip SSL verification** | Bypass TLS certificate validation. Shows an inline warning when enabled. Use only for local/self-signed setups. |
 | **API Key** | Your Immich user API key. Stored in the OS keychain by default — never written to plain TOML. |
-| **Admin API Key** | Optional elevated key. Required only if you want Immich background jobs paused during upload/stack. Also stored in the keychain. |
+| **Admin API Key** | Optional elevated key. Required only if you want Immich background jobs paused during upload/stack. Also stored in the keyring. |
 
 ### Connection Testing
 
@@ -19,15 +19,17 @@ Server-required tabs: all Upload tabs, Archive from Immich, and Stack. See [CLI 
 
 ### Admin API Key and Job Pausing
 
-Immich can pause background jobs while immich-go runs (`pause-immich-jobs`, enabled by default for upload/stack). That API call needs an **admin** key.
+Immich can pause background jobs while immich-go runs (`pause-immich-jobs`, enabled by default upstream for upload/stack). That API call needs an **admin** key.
 
-| Admin key set? | Pause jobs preference | What the GUI does |
+**Where to control pausing:** `pause-immich-jobs` is a **per-tab Advanced Flags row** on upload and Stack tabs — not a Config-tab toggle. In simple mode, the flag is not emitted unless you enable it on the tab's Advanced card.
+
+| Admin key set? | Advanced row enabled? | What the GUI does |
 |----------------|----------------------|-------------------|
-| Yes | On (default) | Jobs can be paused during the run |
-| No | On (default) | **Auto-disables** pausing and adds a warning — avoids a hard `403 Forbidden` abort |
-| Any | Off | Emits pause disabled; no admin key needed |
+| Yes | Yes (user checked) | Emits `--pause-immich-jobs` (or the value you set) |
+| No | Yes | **Auto-disables** pausing via safety pass: emits `--pause-immich-jobs=false` and adds a warning — avoids a hard `403 Forbidden` abort |
+| Any | No (default) | Flag not emitted; immich-go applies its own default |
 
-**Recommendation:** create an admin API key in Immich if you upload large libraries and want Immich to stop thumbnail/metadata jobs from competing for I/O. Otherwise leave the admin field empty and accept that pausing stays off.
+**Recommendation:** create an admin API key in Immich if you upload large libraries and want Immich to stop thumbnail/metadata jobs from competing for I/O. Otherwise leave the admin field empty; the safety pass prevents 403 errors when pausing would otherwise be requested.
 
 ## Configuration Lifecycle
 
@@ -58,10 +60,6 @@ API keys are handled securely:
 
 Secrets are passed to immich-go through **environment variables**, not command-line arguments. The command preview masks all secret values.
 
-### Admin API Key and Job Pausing
-
-Immich can pause background jobs while immich-go runs (`pause-immich-jobs`). That API call needs an **admin** key. Enable the **Pause Immich jobs** advanced row on upload/stack tabs when you want pausing; without an admin key the GUI auto-emits `--pause-immich-jobs=false` to avoid a `403 Forbidden` abort.
-
 ## immich-go Binary Management
 
 ```mermaid
@@ -72,29 +70,41 @@ flowchart TD
     classDef run fill:#8b5cf6,stroke:#6d28d9,color:#fff,stroke-width:2px
     classDef done fill:#10b981,stroke:#047857,color:#fff,stroke-width:2px
 
-    Start([Launch requested]):::startEnd
+    Start([Download / update requested<br/>from Config tab]):::startEnd
     Check{"Binary installed?"}:::check
-    Download[Download from<br/>GitHub Releases]:::download
-    Verify[Verify SHA256 checksum]:::download
+    Download[Download archive from<br/>GitHub Releases]:::download
+    Checksums{"checksums.txt<br/>present?"}:::check
+    Verify[Verify archive SHA256]:::download
+    Extract[Extract to version subdir]:::download
+    PostCheck[Run immich-go version<br/>post-extract check]:::download
     Launch[Prepare argv + env secrets]:::run
     Execute[Open terminal + run immich-go]:::run
     Done([Process running]):::done
 
     Start --> Check
-    Check -->|Yes| Launch
-    Check -->|No| Download
-    Download --> Verify
-    Verify -->|checksum OK| Launch
+    Check -->|No or update| Download
+    Check -->|Yes, run only| Launch
+    Download --> Checksums
+    Checksums -->|missing| Abort([Install aborted<br/>fail-closed]):::startEnd
+    Checksums -->|found| Verify
+    Verify -->|fail| Abort
+    Verify -->|OK| Extract
+    Extract --> PostCheck
+    PostCheck -->|fail| Abort
+    PostCheck -->|OK| Launch
     Launch --> Execute
     Execute --> Done
 ```
 
-The GUI bundles no immich-go binary inside the app. On first use it can download one from [GitHub Releases](https://github.com/simulot/immich-go/releases).
+The GUI bundles no immich-go binary inside the app. Downloads are triggered from the **Config tab** (or when you confirm a download prompt before run) — not on every application launch.
 
 | Location | Path |
 |----------|------|
-| Binary directory | `~/.immich-go-gui/bin/` |
+| Binary base directory | `~/.immich-go-gui/bin/` |
+| Versioned binary | `~/.immich-go-gui/bin/{version}/immich-go` (or `immich-go.exe` on Windows) |
 | Metadata file | `~/.immich-go-gui/bin/metadata.json` |
+
+`metadata.json` records `selected_version`, per-version paths, and download metadata. Legacy installs may still have a flat `~/.immich-go-gui/bin/immich-go`; the resolver checks version subdirectories first.
 
 The Config tab shows:
 

--- a/docs/user-guide/glossary.md
+++ b/docs/user-guide/glossary.md
@@ -26,7 +26,7 @@ Terms used throughout Immich-Go GUI documentation and the immich-go ecosystem.
 | **iCloud export** | Local export of an iCloud Photos library used as an import source. |
 | **Picasa** | Legacy Google Photos / Picasa Web Albums export layout. |
 | **TAB key** | Stable internal id such as `upload-folder` or `archive-gp` (not the keyboard key). |
-| **Allowlist** | Per-tab set of CLI flags the GUI is allowed to emit (`TAB_ALLOWED_FLAGS`). |
+| **Allowlist** | Per-tab set of CLI flags the GUI may emit (`TAB_ALLOWED_FLAGS` shim; authoritative source is `core/flags.toml` via `flag_registry`) |
 | **Golden fixture** | Checked-in expected command state used by tests. |
 | **Process lock** | File under `{config_dir}/locks/` preventing concurrent GUI-launched jobs. |
 | **Nuitka** | Python compiler used to produce standalone release binaries. |

--- a/docs/user-guide/profiles.md
+++ b/docs/user-guide/profiles.md
@@ -51,8 +51,7 @@ Each profile's `config.toml` includes:
 
 - Server URL and SSL settings
 - Theme and advanced mode preference
-- Global advanced defaults (timeout, concurrent tasks, etc.)
-- **form_state** — Saved field values for every workflow tab (paths, checkboxes, advanced flags)
+- **form_state** — Per-tab field values and advanced-row enablement (timeout, concurrent tasks, on-errors, etc. are per-tab, not global)
 
 API keys are stored separately in the keyring (or `secrets.toml` as fallback), scoped by profile name.
 

--- a/docs/user-guide/troubleshooting.md
+++ b/docs/user-guide/troubleshooting.md
@@ -49,7 +49,7 @@ Common issues and how to resolve them. For short Q&A, see the [FAQ](faq.md). For
 - **Linux:** Ensure a terminal emulator is installed (`gnome-terminal`, `konsole`, `xterm`, etc.). Set preferred terminal in Config if Auto detection fails.
 - **macOS:** Terminal.app or iTerm should be available on PATH.
 - **Windows:** cmd.exe is used by default; verify it is accessible.
-- Check file permissions on the immich-go binary in `~/.immich-go-gui/bin/`.
+- Check file permissions on the immich-go binary in `~/.immich-go-gui/bin/{version}/` (or legacy flat path under `~/.immich-go-gui/bin/`).
 
 ## Server Connection Failed
 
@@ -74,7 +74,7 @@ Common issues and how to resolve them. For short Q&A, see the [FAQ](faq.md). For
 **Solutions:**
 
 1. Add an **Admin API Key** on the Config tab, or
-2. Disable job pausing (advanced / config advanced settings), or
+2. On each upload/Stack tab, open **Advanced Flags** and leave the `pause-immich-jobs` row disabled (or disable it if already enabled), or
 3. Upgrade to GUI **≥ 1.1.2**, which auto-disables pausing when no admin key is present and warns instead of failing hard
 
 See [Configuration — Admin API Key and Job Pausing](configuration.md#admin-api-key-and-job-pausing).


### PR DESCRIPTION
## Summary
- Updates configuration, compatibility, troubleshooting, and maintainer docs for per-tab advanced `pause-immich-jobs`
- Documents versioned binary paths and checksum fail-closed behavior
- Refreshes `.agents/AGENTS.md` to reflect implemented 1.4.0 emission model

## Test plan
- [x] MkDocs build (manual)

**Stacks on:** pre-release hardening PR

Made with [Cursor](https://cursor.com)