### PR TITLE
fix: skip save prompt when configuration is unchanged

### DIFF
--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -261,6 +261,12 @@ class ImmichGoGUI(
                 event.ignore()
                 return
 
+        if not self.has_unsaved_changes():
+            if hasattr(self, "log"):
+                self.log.info("GUI closed")
+            event.accept()
+            return
+
         reply = QMessageBox.question(
             self,
             "Save Configuration",

--- a/gui/mixins/persistence.py
+++ b/gui/mixins/persistence.py
@@ -99,6 +99,50 @@ class PersistenceMixin:
 
         self.update_window_title()
         self._update_secret_status()
+        self._mark_configuration_clean()
+
+    def _collect_persisted_state(self) -> dict:
+        """Snapshot of widget state that save_configuration would persist."""
+        config_inputs = self.inputs.get("config", {})
+        state = {
+            "server_url": config_inputs.get("server").text()
+            if config_inputs.get("server")
+            else "",
+            "skip_ssl": config_inputs["skip-ssl"].isChecked()
+            if config_inputs.get("skip-ssl")
+            else False,
+            "secrets_provider": config_inputs["secret_provider"].currentData()
+            if config_inputs.get("secret_provider")
+            else "keyring",
+            "allow_untested_updates": config_inputs["allow_untested_updates"].isChecked()
+            if config_inputs.get("allow_untested_updates")
+            else False,
+            "preferred_terminal": config_inputs["preferred_terminal"].currentText()
+            if config_inputs.get("preferred_terminal")
+            else "auto",
+            "theme_mode": self.theme_mode_combo.currentText()
+            if hasattr(self, "theme_mode_combo")
+            else normalize_theme_mode(self.theme_mode),
+            "advanced_mode": bool(getattr(self, "is_advanced", False)),
+            "api_key": config_inputs.get("api_key").text().strip()
+            if config_inputs.get("api_key")
+            else "",
+            "admin_api_key": config_inputs.get("admin_api_key").text().strip()
+            if config_inputs.get("admin_api_key")
+            else "",
+            "form_state": self.collect_form_state(),
+        }
+        if state["secrets_provider"] is None:
+            state["secrets_provider"] = "keyring"
+        return state
+
+    def _mark_configuration_clean(self) -> None:
+        self._config_clean_snapshot = self._collect_persisted_state()
+
+    def has_unsaved_changes(self) -> bool:
+        if not hasattr(self, "_config_clean_snapshot"):
+            return False
+        return self._collect_persisted_state() != self._config_clean_snapshot
 
     def save_configuration(self, show_popup: bool = True):
         self.app_config.server_url = self.inputs["config"]["server"].text()
@@ -172,6 +216,7 @@ class PersistenceMixin:
                 msg,
             )
         self._update_secret_status()
+        self._mark_configuration_clean()
 
     def _probe_keyring(self) -> bool:
         """One-time check: can we actually talk to the keyring?"""

--- a/gui/mixins/profiles_ui.py
+++ b/gui/mixins/profiles_ui.py
@@ -22,21 +22,22 @@ class ProfilesUIMixin:
         if target_name == active:
             return
 
-        reply = QMessageBox.question(
-            self,
-            "Switch Profile",
-            f"Save changes to current profile '{active}' before switching?",
-            QMessageBox.StandardButton.Save
-            | QMessageBox.StandardButton.Discard
-            | QMessageBox.StandardButton.Cancel,
-            QMessageBox.StandardButton.Save,
-        )
+        if self.has_unsaved_changes():
+            reply = QMessageBox.question(
+                self,
+                "Switch Profile",
+                f"Save changes to current profile '{active}' before switching?",
+                QMessageBox.StandardButton.Save
+                | QMessageBox.StandardButton.Discard
+                | QMessageBox.StandardButton.Cancel,
+                QMessageBox.StandardButton.Save,
+            )
 
-        if reply == QMessageBox.StandardButton.Cancel:
-            self.update_profiles_menu()
-            return
-        elif reply == QMessageBox.StandardButton.Save:
-            self.save_configuration()
+            if reply == QMessageBox.StandardButton.Cancel:
+                self.update_profiles_menu()
+                return
+            if reply == QMessageBox.StandardButton.Save:
+                self.save_configuration()
 
         try:
             set_active_profile_name(target_name)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -57,6 +57,7 @@ def gui(qapp):
             g._conn_test_debounce.stop()
             g._conn_test_debounce.timeout.disconnect()
         g._auto_test_connection = lambda: None
+        g._mark_configuration_clean()
         yield g
         g._force_close = True
         g.close()
@@ -88,6 +89,9 @@ def _clear_profiles_cache():
 def _reset_shared_config(gui):
     cfg = gui.inputs["config"]
     cfg["skip-ssl"].setChecked(False)
+    if cfg.get("server"):
+        cfg["server"].clear()
+    gui._mark_configuration_clean()
     yield
     gui.toggle_advanced(False)
     if hasattr(gui, "reset_advanced_flags"):

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -32,6 +32,21 @@ def test_secret_store_migration():
         )
         mock_settings.remove.assert_called_once_with("api_key")
 
+def test_has_unsaved_changes_detects_widget_edits(gui):
+    gui._mark_configuration_clean()
+    assert gui.has_unsaved_changes() is False
+    gui.inputs["config"]["server"].setText("http://edited:2283")
+    assert gui.has_unsaved_changes() is True
+
+
+def test_save_marks_configuration_clean(gui, monkeypatch):
+    gui._mark_configuration_clean()
+    gui.inputs["config"]["server"].setText("http://edited:2283")
+    assert gui.has_unsaved_changes() is True
+    gui.save_configuration(show_popup=False)
+    assert gui.has_unsaved_changes() is False
+
+
 def test_config_roundtrip(tmp_path, monkeypatch):
     cfg_file = tmp_path / "config.toml"
     monkeypatch.setenv("IMMICH_GO_GUI_CONFIG", str(cfg_file))

--- a/tests/test_profiles_ui.py
+++ b/tests/test_profiles_ui.py
@@ -75,19 +75,32 @@ def test_profile_switch_save_discard_cancel(gui, monkeypatch):
     monkeypatch.setattr("gui.mixins.profiles_ui.active_profile_name", lambda: "default")
 
     actions.append(QMessageBox.StandardButton.Cancel)
+    gui._mark_configuration_clean()
+    gui.inputs["config"]["server"].setText("http://changed:2283")
     gui.switch_profile("work")
     assert "active:work" not in actions
 
     actions.clear()
-    actions.append(QMessageBox.StandardButton.Discard)
+    gui._mark_configuration_clean()
     gui.switch_profile("work")
     assert "saved" not in actions
     assert "active:work" in actions
     assert "loaded" in actions
 
     actions.clear()
-    actions.append(QMessageBox.StandardButton.Save)
+    actions.append(QMessageBox.StandardButton.Discard)
+    gui._mark_configuration_clean()
+    gui.inputs["config"]["server"].setText("http://changed:2283")
     gui.switch_profile("home")
-    assert "saved" in actions
+    assert "saved" not in actions
     assert "active:home" in actions
+    assert "loaded" in actions
+
+    actions.clear()
+    actions.append(QMessageBox.StandardButton.Save)
+    gui._mark_configuration_clean()
+    gui.inputs["config"]["server"].setText("http://save-me:2283")
+    gui.switch_profile("office")
+    assert "saved" in actions
+    assert "active:office" in actions
 

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -30,9 +30,10 @@ def test_close_event_save_prompt(gui, monkeypatch):
     from PySide6.QtGui import QCloseEvent
     from PySide6.QtWidgets import QMessageBox
 
-    calls = {"save": 0}
+    calls = {"save": 0, "question": 0}
 
     def fake_question(*args, **kwargs):
+        calls["question"] += 1
         return QMessageBox.StandardButton.Save
 
     monkeypatch.setattr("PySide6.QtWidgets.QMessageBox.question", fake_question)
@@ -42,8 +43,11 @@ def test_close_event_save_prompt(gui, monkeypatch):
         lambda show_popup=True: calls.__setitem__("save", calls["save"] + 1),
     )
     monkeypatch.setattr("gui.main_window.scan_locks", list)
+    gui._mark_configuration_clean()
+    gui.inputs["config"]["server"].setText("http://changed:2283")
     event = QCloseEvent()
     gui.closeEvent(event)
+    assert calls["question"] == 1
     assert calls["save"] == 1
     assert event.isAccepted()
 
@@ -61,6 +65,8 @@ def test_close_event_cancel_ignores(gui, monkeypatch):
         lambda show_popup=True: (_ for _ in ()).throw(AssertionError("save")),
     )
     monkeypatch.setattr("gui.main_window.scan_locks", list)
+    gui._mark_configuration_clean()
+    gui.inputs["config"]["server"].setText("http://changed:2283")
     event = QCloseEvent()
     gui.closeEvent(event)
     assert not event.isAccepted()
@@ -69,21 +75,43 @@ def test_close_event_discard_no_save(gui, monkeypatch):
     from PySide6.QtGui import QCloseEvent
     from PySide6.QtWidgets import QMessageBox
 
-    calls = {"save": 0}
+    calls = {"save": 0, "question": 0}
 
-    monkeypatch.setattr(
-        "PySide6.QtWidgets.QMessageBox.question",
-        lambda *a, **k: QMessageBox.StandardButton.Discard,
-    )
+    def fake_question(*args, **kwargs):
+        calls["question"] += 1
+        return QMessageBox.StandardButton.Discard
+
+    monkeypatch.setattr("PySide6.QtWidgets.QMessageBox.question", fake_question)
     monkeypatch.setattr(
         gui,
         "save_configuration",
         lambda show_popup=True: calls.__setitem__("save", calls["save"] + 1),
     )
     monkeypatch.setattr("gui.main_window.scan_locks", list)
+    gui._mark_configuration_clean()
+    gui.inputs["config"]["server"].setText("http://changed:2283")
     event = QCloseEvent()
     gui.closeEvent(event)
+    assert calls["question"] == 1
     assert calls["save"] == 0
+    assert event.isAccepted()
+
+
+def test_close_event_clean_skips_save_prompt(gui, monkeypatch):
+    from PySide6.QtGui import QCloseEvent
+
+    calls = {"question": 0}
+
+    def fake_question(*args, **kwargs):
+        calls["question"] += 1
+        return kwargs.get("defaultButton")
+
+    monkeypatch.setattr("PySide6.QtWidgets.QMessageBox.question", fake_question)
+    monkeypatch.setattr("gui.main_window.scan_locks", list)
+    gui._mark_configuration_clean()
+    event = QCloseEvent()
+    gui.closeEvent(event)
+    assert calls["question"] == 0
     assert event.isAccepted()
 
 def test_icon_cache_cleared_on_theme_switch(gui, monkeypatch):


### PR DESCRIPTION
## Summary
- Track a clean configuration snapshot after load and save
- Only show Save/Discard on window close or profile switch when widgets differ from that snapshot
- Covers server settings, secrets, theme, advanced mode, and tab form state

## Test plan
- [x] `uv run pytest tests/test_status.py tests/test_profiles_ui.py tests/test_persistence.py::test_has_unsaved_changes_detects_widget_edits tests/test_persistence.py::test_save_marks_configuration_clean`
- [ ] Open app, make no edits, close window — no save prompt
- [ ] Edit server URL, close window — save prompt appears
- [ ] Switch profile with no edits — no save prompt


Made with [Cursor](https://cursor.com)