### PR TITLE
feat: config schema v3 persistence and Linux credential fixes

### DIFF
--- a/core/__init__.py
+++ b/core/__init__.py
@@ -67,6 +67,7 @@ from .config_manager import (
     save_config,
     save_secret_with_fallback,
     save_secrets,
+    save_server_url,
     set_api_key,
 )
 from .flag_registry import (
@@ -158,6 +159,7 @@ __all__ = [
     "save_config",
     "save_secret_with_fallback",
     "save_secrets",
+    "save_server_url",
     "set_api_key",
     # binary_manager
     "BINARY_BASE_DIR",

--- a/core/config_manager.py
+++ b/core/config_manager.py
@@ -240,7 +240,8 @@ def load_config(path: Path | None = None, profile_name: str | None = None) -> Ap
         )
         return cfg
 
-    cfg.schema_version = data.get("schema_version", 2)
+    schema_version = data.get("schema_version", 2)
+    cfg.schema_version = schema_version
 
     gen = data.get("general", {})
     cfg.theme_mode = gen.get("theme", "system")
@@ -251,13 +252,54 @@ def load_config(path: Path | None = None, profile_name: str | None = None) -> Ap
     srv = data.get("server", {})
     cfg.server_url = srv.get("url", "")
     cfg.skip_ssl = srv.get("skip_ssl", False)
+    cfg.client_timeout_minutes = int(srv.get("client_timeout_minutes", 60))
 
     sec = data.get("secrets", {})
     cfg.secrets_provider = sec.get("provider", "keyring")
 
-    cfg.form_state = data.get("form_state", {})
+    if schema_version < 3:
+        form_state = data.get("form_state", {})
+        if isinstance(form_state, dict):
+            migrated_timeout = _extract_legacy_client_timeout(form_state)
+            if migrated_timeout is not None:
+                cfg.client_timeout_minutes = migrated_timeout
+            _log.info(
+                "Migrated config schema v%s -> v3 at %s (discarded legacy form_state)",
+                schema_version,
+                path,
+            )
+        cfg.schema_version = 3
+    else:
+        cfg.form_state = data.get("form_state", {})
 
+    _log.info(
+        "Loaded config profile=%s path=%s schema_version=%s",
+        cfg.profile_name,
+        path,
+        cfg.schema_version,
+    )
     return cfg
+
+
+def _extract_legacy_client_timeout(form_state: dict) -> int | None:
+    """Pull enabled client-timeout from legacy per-tab advanced form_state."""
+    advanced = form_state.get("advanced", {})
+    if not isinstance(advanced, dict):
+        return None
+    for tab_adv in advanced.values():
+        if not isinstance(tab_adv, dict):
+            continue
+        row = tab_adv.get("client-timeout")
+        if not isinstance(row, dict) or not row.get("enabled"):
+            continue
+        value = row.get("value")
+        if value is None:
+            continue
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            continue
+    return None
 
 
 def save_config(
@@ -269,7 +311,7 @@ def save_config(
         path = default_config_path(target_prof)
 
     data = {
-        "schema_version": 2,
+        "schema_version": 3,
         "general": {
             "theme": config.theme_mode,
             "advanced_mode": config.advanced_mode,
@@ -279,11 +321,11 @@ def save_config(
         "server": {
             "url": config.server_url,
             "skip_ssl": config.skip_ssl,
+            "client_timeout_minutes": config.client_timeout_minutes,
         },
         "secrets": {
             "provider": config.secrets_provider,
         },
-        "form_state": config.form_state or {},
     }
 
     text = tomli_w.dumps(data)

--- a/core/config_manager.py
+++ b/core/config_manager.py
@@ -242,6 +242,7 @@ def load_config(path: Path | None = None, profile_name: str | None = None) -> Ap
 
     schema_version = data.get("schema_version", 2)
     cfg.schema_version = schema_version
+    migrated = False
 
     gen = data.get("general", {})
     cfg.theme_mode = gen.get("theme", "system")
@@ -269,8 +270,15 @@ def load_config(path: Path | None = None, profile_name: str | None = None) -> Ap
                 path,
             )
         cfg.schema_version = 3
+        migrated = True
     else:
         cfg.form_state = data.get("form_state", {})
+
+    if migrated:
+        _log.info(
+            "Configuration format upgraded; workflow tab fields are no longer saved."
+        )
+        save_config(cfg, path=path, profile_name=cfg.profile_name)
 
     _log.info(
         "Loaded config profile=%s path=%s schema_version=%s",
@@ -327,6 +335,37 @@ def save_config(
             "provider": config.secrets_provider,
         },
     }
+
+    text = tomli_w.dumps(data)
+    _atomic_write_text(path, text, mode=0o644)
+
+
+def save_server_url(
+    server_url: str,
+    path: Path | None = None,
+    profile_name: str | None = None,
+) -> None:
+    """Update only ``[server].url`` in the config file without resetting other keys."""
+    if path is None:
+        path = default_config_path(profile_name)
+
+    if path.exists():
+        try:
+            data = tomllib.loads(path.read_text(encoding="utf-8"))
+        except Exception as exc:
+            _log.warning(
+                "Failed to read config for server URL update %s: %s", path, exc
+            )
+            data = {}
+    else:
+        data = {}
+
+    server = data.get("server")
+    if not isinstance(server, dict):
+        server = {}
+    server["url"] = server_url
+    data["server"] = server
+    data.setdefault("schema_version", 3)
 
     text = tomli_w.dumps(data)
     _atomic_write_text(path, text, mode=0o644)

--- a/core/config_manager.py
+++ b/core/config_manager.py
@@ -157,16 +157,29 @@ def default_config_dir() -> Path:
         return Path.home() / ".config" / "immich-go-gui"
 
 
+def resolve_profile_name(
+    profile_name: str | None = None, config: AppConfig | None = None
+) -> str:
+    """Resolve a non-empty profile name for config path and persistence."""
+    from .profile_manager import active_profile_name
+
+    candidate = profile_name
+    if not candidate and config is not None:
+        candidate = config.profile_name
+    if not candidate:
+        candidate = active_profile_name()
+    return candidate or "default"
+
+
 def default_config_path(profile_name: str | None = None) -> Path:
     """Returns the path to the config TOML file for the given or active profile."""
     env_override = os.environ.get("IMMICH_GO_GUI_CONFIG", "").strip()
     if env_override:
         return Path(env_override)
 
-    from .profile_manager import active_profile_name, profile_config_path
+    from .profile_manager import profile_config_path
 
-    target_profile = profile_name or active_profile_name()
-    return profile_config_path(target_profile)
+    return profile_config_path(resolve_profile_name(profile_name))
 
 
 def default_secrets_path(profile_name: str | None = None) -> Path:
@@ -221,9 +234,7 @@ def load_config(path: Path | None = None, profile_name: str | None = None) -> Ap
         path = default_config_path(profile_name)
 
     cfg = AppConfig()
-    from .profile_manager import active_profile_name
-
-    cfg.profile_name = profile_name or active_profile_name()
+    cfg.profile_name = resolve_profile_name(profile_name)
 
     if not path.exists():
         return cfg
@@ -314,7 +325,8 @@ def save_config(
     config: AppConfig, path: Path | None = None, profile_name: str | None = None
 ) -> None:
     """Saves AppConfig to user-level TOML file."""
-    target_prof = profile_name or config.profile_name
+    target_prof = resolve_profile_name(profile_name, config)
+    config.profile_name = target_prof
     if path is None:
         path = default_config_path(target_prof)
 

--- a/core/models.py
+++ b/core/models.py
@@ -87,6 +87,7 @@ class AppConfig:
 
     server_url: str = ""
     skip_ssl: bool = False
+    client_timeout_minutes: int = 60
 
     secrets_provider: str = "keyring"
 

--- a/core/profile_manager.py
+++ b/core/profile_manager.py
@@ -18,7 +18,7 @@ except ModuleNotFoundError:
 
 import tomli_w
 
-from .config_manager import SecretStore, _atomic_write_text, default_config_dir
+from .config_manager import SecretStore, _atomic_write_text
 
 _log = logging.getLogger(__name__)
 
@@ -36,11 +36,15 @@ _PROFILE_NAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9 _-]{0,63}$")
 
 def profiles_root() -> Path:
     """Returns the base directory for profile storage."""
+    from .config_manager import default_config_dir
+
     return default_config_dir() / "profiles"
 
 
 def global_profiles_path() -> Path:
     """Returns the path to the global profiles.toml index file."""
+    from .config_manager import default_config_dir
+
     return default_config_dir() / "profiles.toml"
 
 
@@ -149,6 +153,8 @@ def migrate_single_config_to_default() -> None:
     env_override = os.environ.get("IMMICH_GO_GUI_CONFIG", "").strip()
     if env_override:
         return
+
+    from .config_manager import default_config_dir
 
     base_dir = default_config_dir()
     old_config = base_dir / "config.toml"

--- a/core/profile_manager.py
+++ b/core/profile_manager.py
@@ -3,6 +3,7 @@
 Pure Python module, Qt-free.
 """
 
+import logging
 import os
 import re
 import shutil
@@ -18,6 +19,8 @@ except ModuleNotFoundError:
 import tomli_w
 
 from .config_manager import SecretStore, _atomic_write_text, default_config_dir
+
+_log = logging.getLogger(__name__)
 
 
 @dataclass
@@ -164,20 +167,64 @@ def migrate_single_config_to_default() -> None:
     default_p_dir.mkdir(parents=True, exist_ok=True)
 
     if old_config.exists() and not default_cfg.exists():
-        shutil.copy2(old_config, default_cfg)
         try:
+            shutil.copy2(old_config, default_cfg)
+            if not default_cfg.exists():
+                _log.error(
+                    "Profile migration failed: copy of %s did not create %s",
+                    old_config,
+                    default_cfg,
+                )
+                return
+            if default_cfg.read_text(encoding="utf-8") != old_config.read_text(
+                encoding="utf-8"
+            ):
+                _log.error(
+                    "Profile migration failed: copied config at %s does not match source",
+                    default_cfg,
+                )
+                default_cfg.unlink(missing_ok=True)
+                return
             bak = base_dir / "config.toml.pre-profile.bak"
             old_config.rename(bak)
-        except Exception:
-            pass
+            _log.info(
+                "Migrated legacy config %s -> %s",
+                old_config,
+                default_cfg,
+            )
+        except Exception as exc:
+            _log.error(
+                "Profile migration failed copying %s to %s: %s",
+                old_config,
+                default_cfg,
+                exc,
+            )
+            return
 
     if old_secrets.exists() and not default_sec.exists():
-        shutil.copy2(old_secrets, default_sec)
         try:
+            shutil.copy2(old_secrets, default_sec)
+            if not default_sec.exists():
+                _log.error(
+                    "Profile migration failed: copy of %s did not create %s",
+                    old_secrets,
+                    default_sec,
+                )
+                return
             sbak = base_dir / "secrets.toml.pre-profile.bak"
             old_secrets.rename(sbak)
-        except Exception:
-            pass
+            _log.info(
+                "Migrated legacy secrets %s -> %s",
+                old_secrets,
+                default_sec,
+            )
+        except Exception as exc:
+            _log.error(
+                "Profile migration failed copying %s to %s: %s",
+                old_secrets,
+                default_sec,
+                exc,
+            )
 
     if default_cfg.exists() or default_sec.exists():
         now_iso = datetime.now(UTC).isoformat()

--- a/core/profile_manager.py
+++ b/core/profile_manager.py
@@ -212,23 +212,15 @@ def migrate_single_config_to_default() -> None:
             shutil.copy2(old_secrets, default_sec)
             if not default_sec.exists():
                 _log.error(
-                    "Profile migration failed: copy of %s did not create %s",
-                    old_secrets,
-                    default_sec,
+                    "Profile migration failed: secrets copy did not create target file"
                 )
                 return
             sbak = base_dir / "secrets.toml.pre-profile.bak"
             old_secrets.rename(sbak)
-            _log.info(
-                "Migrated legacy secrets %s -> %s",
-                old_secrets,
-                default_sec,
-            )
+            _log.info("Migrated legacy secrets to default profile")
         except Exception as exc:
             _log.error(
-                "Profile migration failed copying %s to %s: %s",
-                old_secrets,
-                default_sec,
+                "Profile migration failed copying secrets to default profile: %s",
                 exc,
             )
 

--- a/docs/developer-guide/adding-tabs-and-flags.md
+++ b/docs/developer-guide/adding-tabs-and-flags.md
@@ -51,7 +51,7 @@ For every simple-mode bool, the TOML `default` must match the CLI default and th
 - Add sidebar entry / stacked page / sub-tab as needed
 - Create simple-mode widgets for `mode = "simple"` flags
 - Advanced rows are generated from the registry automatically
-- Wire save/load through `form_state`
+- Wire widgets into `inputs` / `adv_rows`; `collect_form_state()` gathers runtime state for `build_plan_from_state()` (not persisted to `config.toml`)
 
 ### 3. Add tests and fixtures
 

--- a/docs/developer-guide/architecture.md
+++ b/docs/developer-guide/architecture.md
@@ -71,7 +71,8 @@ immich-go-gui/
 │   ├── mixins/            # Focused QMainWindow mixins (all ≤300 lines)
 │   │   ├── layout.py      # Main layout & tab assembly
 │   │   ├── form_helpers.py# Inline field errors & helper controls
-│   │   ├── form_state.py  # State collection & restoration
+│   │   ├── form_state.py  # Runtime state collection for command building
+│   │   ├── app_update.py  # GUI release check UI
 │   │   ├── execution.py   # Command building & terminal execution
 │   │   ├── confirm_dialog.py # Run confirmation dialog
 │   │   ├── persistence.py # TOML config & secret store persistence
@@ -125,7 +126,7 @@ The `core/` package MUST NOT import PySide6 or Qt. All network, file I/O, subpro
 
 ```mermaid
 flowchart LR
-    State[form_state dict] --> Build[build_plan_from_state<br/>validates + builds]
+    WidgetState[collect_form_state<br/>runtime only] --> Build[build_plan_from_state<br/>validates + builds]
     Build --> Plan[CommandPlan<br/>argv · env · warnings]
     Plan --> Mask[mask_command_for_display]
     Mask --> Preview[Preview pane]
@@ -202,9 +203,10 @@ See [Environment Variables](../reference/environment-variables.md) for the env v
 
 ## Configuration Persistence
 
-- Per-profile TOML files via `core/config_manager.py` and `core/profile_manager.py`
-- Form field values stored in `form_state` dict within config
-- Legacy QSettings migration for API keys handled once on startup
+- Per-profile TOML files via `core/config_manager.py` and `core/profile_manager.py` (schema v3)
+- **Persisted:** Configuration-tab fields only (server URL, timeout, theme, advanced card, etc.)
+- **Session-only:** Workflow tab widgets and per-tab advanced rows (`collect_form_state()` at run time; not written to disk)
+- Legacy QSettings and v2 `form_state` migration handled on startup
 
 ## Process Lock Lifecycle
 

--- a/docs/developer-guide/architecture.md
+++ b/docs/developer-guide/architecture.md
@@ -72,7 +72,6 @@ immich-go-gui/
 │   │   ├── layout.py      # Main layout & tab assembly
 │   │   ├── form_helpers.py# Inline field errors & helper controls
 │   │   ├── form_state.py  # Runtime state collection for command building
-│   │   ├── app_update.py  # GUI release check UI
 │   │   ├── execution.py   # Command building & terminal execution
 │   │   ├── confirm_dialog.py # Run confirmation dialog
 │   │   ├── persistence.py # TOML config & secret store persistence

--- a/docs/developer-guide/core-modules.md
+++ b/docs/developer-guide/core-modules.md
@@ -12,7 +12,7 @@ Pure dataclasses and enums. No I/O.
 
 | Type | Purpose |
 |------|---------|
-| `AppConfig` | User configuration model (server, theme, form_state, etc.) |
+| `AppConfig` | User configuration model (server, theme, client timeout, etc.) |
 | `CommandPlan` | Resolved argv, env, display_argv, warnings, errors, `emission_log` |
 | `ValidationResult` | Form validation errors and warnings |
 | `BinaryStatus` | immich-go binary health display data |
@@ -117,6 +117,19 @@ immich-go binary lifecycle.
 | `BINARY_BASE_DIR` | `~/.immich-go-gui/bin/` (versioned subdirs: `bin/{version}/immich-go`) |
 
 Downloads from GitHub Releases with SHA256 verification.
+
+### `core/app_update.py`
+
+Immich-Go **GUI** release checks (not immich-go CLI).
+
+| Function | Purpose |
+|----------|---------|
+| `get_latest_gui_release()` | Fetch latest tag from `shitan198u/immich-go-gui` releases API |
+| `clean_gui_release_version()` | Normalize Release Please tags (`immich-go-gui-v1.2.0` → `1.2.0`) |
+| `is_update_available()` | Compare installed vs latest semver |
+| `is_parseable_semver()` | Detect `dev` / non-release builds |
+
+UI handler lives in `gui/mixins/app_update.py`.
 
 ### `core/network.py`
 

--- a/docs/developer-guide/core-modules.md
+++ b/docs/developer-guide/core-modules.md
@@ -118,19 +118,6 @@ immich-go binary lifecycle.
 
 Downloads from GitHub Releases with SHA256 verification.
 
-### `core/app_update.py`
-
-Immich-Go **GUI** release checks (not immich-go CLI).
-
-| Function | Purpose |
-|----------|---------|
-| `get_latest_gui_release()` | Fetch latest tag from `shitan198u/immich-go-gui` releases API |
-| `clean_gui_release_version()` | Normalize Release Please tags (`immich-go-gui-v1.2.0` → `1.2.0`) |
-| `is_update_available()` | Compare installed vs latest semver |
-| `is_parseable_semver()` | Detect `dev` / non-release builds |
-
-UI handler lives in `gui/mixins/app_update.py`.
-
 ### `core/network.py`
 
 Immich server connectivity.

--- a/docs/reference/config-schema.md
+++ b/docs/reference/config-schema.md
@@ -11,7 +11,7 @@ Immich-Go GUI stores configuration in TOML files. API keys are stored in the OS 
 ├── logs/                      # Rotating GUI log (immich-go-gui.log)
 └── profiles/
     └── {profile_name}/
-        ├── config.toml        # Settings and form state
+        ├── config.toml        # Configuration-page settings only
         └── secrets.toml       # Plaintext secrets (fallback only)
 ```
 
@@ -45,10 +45,10 @@ created_at = "2026-01-01T00:00:00+00:00"
 
 ## config.toml Schema
 
-Current schema version: **2**
+Current schema version: **3**
 
 ```toml
-schema_version = 2
+schema_version = 3
 
 [general]
 theme = "system"                    # "system" | "light" | "dark"
@@ -59,15 +59,13 @@ preferred_terminal = "auto"
 [server]
 url = "https://immich.example.com"
 skip_ssl = false
+client_timeout_minutes = 60
 
 [secrets]
-provider = "keyring"                # "keyring" | "file"
-
-[form_state]
-# Tab-keyed form field values (dynamic keys)
-"upload-folder" = { path = "/photos", dry_run = false }
-"stack" = { date_from = "2020-01-01" }
+provider = "keyring"                # "keyring" | "config"
 ```
+
+Workflow tab field values are **session-only** and are not written to `config.toml`.
 
 ### Section Reference
 
@@ -79,12 +77,16 @@ provider = "keyring"                # "keyring" | "file"
 | `general` | `preferred_terminal` | string | `"auto"` | Terminal emulator preference |
 | `server` | `url` | string | `""` | Immich server base URL |
 | `server` | `skip_ssl` | bool | `false` | Skip TLS verification |
+| `server` | `client_timeout_minutes` | int | `60` | Global HTTP timeout (minutes) for server-connected commands |
 | `secrets` | `provider` | string | `"keyring"` | Secret storage backend |
-| `form_state` | *(tab keys)* | dict | `{}` | Per-tab saved field values (includes `advanced` sub-keys for enabled rows) |
+
+### Schema v2 → v3 migration
+
+On load, legacy `form_state` is discarded. If a v2 config had an **enabled** per-tab `client-timeout` advanced flag, that value is migrated into `server.client_timeout_minutes`.
 
 ## secrets.toml (Fallback)
 
-Used when keyring is unavailable and `secrets.provider = "file"`:
+Used when keyring is unavailable and `secrets.provider = "config"`:
 
 ```toml
 api_key = "your-api-key"

--- a/docs/user-guide/advanced-flags.md
+++ b/docs/user-guide/advanced-flags.md
@@ -17,7 +17,7 @@ A flag reaches the CLI **if and only if** the user explicitly asked for it:
 
 | Source | Rule |
 |--------|------|
-| **Structural** | Always emitted: `server`, `skip-verify-ssl`, `dry-run` (and `from-dry-run` on Immich tabs) |
+| **Structural** | Always emitted: `server`, `skip-verify-ssl`, `client-timeout` / `from-client-timeout` (from Config tab), `dry-run` (and `from-dry-run` on Immich tabs) |
 | **Simple widget** | Emitted when value ≠ TOML default |
 | **Advanced row** | Emitted when the row is enabled |
 | **Safety** | `pause-immich-jobs=false` auto-emitted on upload/stack when no Admin API key is configured |
@@ -48,13 +48,18 @@ These flags are never shown with real values in the preview:
 
 They appear as `***` in the command preview.
 
+## Global connection options (Config tab)
+
+| Setting | Description |
+|---------|-------------|
+| `client_timeout_minutes` | HTTP timeout (minutes) for all server-connected tabs. Emitted as `--client-timeout` and, on Immich-to-Immich tabs, `--from-client-timeout`. |
+
 ## Per-Tab Advanced Flags
 
-Global options like `client-timeout`, `concurrent-tasks`, `device-uuid`, `on-errors`, `pause-immich-jobs`, and `log-level` are configured per tab via Advanced Flags rows (not the Config tab).
+Per-tab advanced rows include options like `concurrent-tasks`, `device-uuid`, `on-errors`, `pause-immich-jobs`, and `log-level`.
 
 | Flag | Type | Description |
 |------|------|-------------|
-| `client-timeout` | duration | HTTP timeout (minutes) |
 | `concurrent-tasks` | int | Parallelism |
 | `device-uuid` | text | Device identifier |
 | `on-errors` | text | `stop`, `continue`, or a max error count (e.g. `10`) |

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -9,11 +9,14 @@ The **Config** tab holds global settings shared across workflow tabs: Immich ser
 | **Server URL** | Base URL of your Immich instance (e.g. `https://immich.local`). Used by upload tabs, Stack, and Archive from Immich. |
 | **Skip SSL verification** | Bypass TLS certificate validation. Shows an inline warning when enabled. Use only for local/self-signed setups. |
 | **API Key** | Your Immich user API key. Stored in the OS keychain by default — never written to plain TOML. |
+| **Client Timeout** | How long each HTTP call to Immich may run (minutes). Low values may fail long uploads or archives. Applied globally as `--client-timeout` (and `--from-client-timeout` on Immich-to-Immich tabs). |
 | **Admin API Key** | Optional elevated key. Required only if you want Immich background jobs paused during upload/stack. Also stored in the keyring. |
 
-### Connection Testing
+### Connection Testing and Saving Server Details
 
-Use **Test Connection** on the Config tab to call `{server}/api/server/about` with your API key. The same endpoint is used as a **pre-flight check** before server-required runs; a failure blocks launch and shows an error.
+Use **Test Connection** to call `{server}/api/server/about` with your API key. The same endpoint is used as a **pre-flight check** before server-required runs; a failure blocks launch and shows an error.
+
+Use **Save Server Details** to persist **only** the server URL and API key (to `config.toml` and keyring). Other Config settings (theme, timeout, skip SSL, etc.) are saved separately via **File → Save Configuration**.
 
 Server-required tabs: all Upload tabs, Archive from Immich, and Stack. See [CLI Command Mapping](../reference/cli-command-mapping.md).
 
@@ -59,6 +62,21 @@ API keys are handled securely:
 2. **Plaintext fallback** — If keyring is unavailable, secrets may be stored in `secrets.toml` inside the profile directory (see [Config Schema](../reference/config-schema.md)).
 
 Secrets are passed to immich-go through **environment variables**, not command-line arguments. The command preview masks all secret values.
+
+## Application Updates (GUI)
+
+The **Application** card checks whether a newer **Immich-Go GUI** release is published on GitHub (separate from the immich-go CLI binary below).
+
+| Element | Description |
+|---------|-------------|
+| **Current Version** | Installed GUI version (or `dev` when running from source) |
+| **Status** | Green when up to date, amber when an update is available, muted for development builds |
+| **Check for Updates** | Fetches the latest release; always shows a status message and dialog |
+| **Releases link** | Opens [GitHub Releases](https://github.com/shitan198u/immich-go-gui/releases) in your browser |
+
+The GUI does **not** download or install itself. When an update is available, use **Open Download Page** in the dialog (or the releases link) and install the new package manually (installer, AppImage, DMG, etc.).
+
+The same check is available from **File → Check for Application Updates…**.
 
 ## immich-go Binary Management
 
@@ -123,7 +141,15 @@ See [immich-go Compatibility](../reference/immich-go-compatibility.md) for versi
 
 ## Saving Configuration
 
-Configuration is saved automatically when you change settings or switch tabs. Each profile has its own `config.toml`. Form field values for workflow tabs are stored in the `form_state` section of that file.
+Configuration is **not** auto-saved. Use explicit save actions:
+
+| Action | What it saves |
+|--------|----------------|
+| **Save Server Details** (Config tab) | Server URL + API key only |
+| **File → Save Configuration** | Theme, client timeout, skip SSL, secret provider, admin API key, advanced card settings, and advanced mode |
+| Close / profile switch prompt | Offers to save pending changes before continuing |
+
+Each profile has its own `config.toml` under `profiles/{name}/`. Workflow tab fields (upload paths, archive destinations, per-tab advanced rows) are **session-only** — they reset when you restart the app or switch profiles without saving Config settings.
 
 ### Config File Locations
 

--- a/docs/user-guide/glossary.md
+++ b/docs/user-guide/glossary.md
@@ -12,8 +12,8 @@ Terms used throughout Immich-Go GUI documentation and the immich-go ecosystem.
 | **Stack** | Group related assets on Immich (burst sequences, RAW+JPEG pairs, HEIC+JPEG, etc.). |
 | **Serverless tab** | Archive tab that never contacts Immich and never emits server/API flags. |
 | **Server-required tab** | Tab that needs Immich credentials (all upload tabs, Stack, Archive from Immich). |
-| **Profile** | Named set of settings + secrets (server URL, theme, form state, API keys). |
-| **form_state** | Per-tab saved field values inside `config.toml`. |
+| **Profile** | Named set of Configuration-tab settings + secrets (server URL, theme, timeout, API keys). |
+| **form_state** | Runtime widget snapshot used to build commands; **not** persisted to `config.toml` (schema v3). |
 | **Advanced mode** | Config toggle that reveals extra immich-go flags on workflow tabs. |
 | **Command preview** | Read-only view of the argv that will run, with secrets masked. |
 | **CommandPlan** | Internal object: argv + env + display argv + validation errors/warnings. |

--- a/docs/user-guide/profiles.md
+++ b/docs/user-guide/profiles.md
@@ -1,6 +1,6 @@
 # Profiles
 
-Profiles let you maintain separate configurations for different Immich servers, environments, or use cases. Each profile has its own settings, form state, and API keys.
+Profiles let you maintain separate configurations for different Immich servers, environments, or use cases. Each profile has its own Configuration-tab settings and API keys.
 
 ## Profile Layout
 
@@ -11,7 +11,7 @@ Profiles are stored under the config directory:
 ├── profiles.toml                 # Index: active profile, profile list
 └── profiles/
     ├── default/
-    │   ├── config.toml           # Settings and form state
+    │   ├── config.toml           # Configuration-page settings
     │   └── secrets.toml          # Plaintext secrets (fallback only)
     └── work/
         ├── config.toml
@@ -22,11 +22,11 @@ The **default** profile is created automatically on first run. It cannot be rena
 
 ## Managing Profiles
 
-From the Config tab you can:
+From the **Profiles** menu you can:
 
 | Action | Description |
 |--------|-------------|
-| **Switch profile** | Select a different active profile; the GUI reloads its settings |
+| **Switch profile** | Select a different active profile; the GUI reloads its settings (prompts to save pending changes first) |
 | **Create** | New empty profile or copy from an existing one |
 | **Duplicate** | Clone an existing profile including config and keyring secrets |
 | **Rename** | Change profile name (not available for `default`) |
@@ -47,11 +47,13 @@ Invalid characters such as `/` or `\` are rejected.
 
 ## What Is Stored Per Profile
 
-Each profile's `config.toml` includes:
+Each profile's `config.toml` includes (schema v3):
 
-- Server URL and SSL settings
-- Theme and advanced mode preference
-- **form_state** — Per-tab field values and advanced-row enablement (timeout, concurrent tasks, on-errors, etc. are per-tab, not global)
+- Server URL, skip SSL, and **client timeout**
+- Theme, advanced mode, preferred terminal, allow untested updates
+- Secret provider preference
+
+Workflow tab fields and per-tab advanced rows are **not** stored per profile — they are session-only.
 
 API keys are stored separately in the keyring (or `secrets.toml` as fallback), scoped by profile name.
 
@@ -72,7 +74,8 @@ Set `IMMICH_GO_GUI_CONFIG` to point at a specific config file. The profile direc
 
 - Use **work** / **home** profiles when you manage multiple Immich instances.
 - Duplicate a working profile before experimenting with advanced flags.
-- Switching profiles reloads all tab fields — save any in-progress changes first if needed.
+- Switching profiles reloads Configuration settings; workflow tab fields reset to defaults.
+- If Configuration settings are unsaved, the GUI prompts once before switching.
 - Keep a **staging** profile pointed at a test Immich server for dry-runs of large Takeouts.
 - Profile names are case-insensitive for uniqueness — `Home` and `home` collide.
 

--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -268,7 +268,7 @@ class ImmichGoGUI(
             event.ignore()
             return
         if reply == QMessageBox.StandardButton.Save:
-            self.save_configuration(show_popup=False)
+            self._save_pending_configuration(show_popup=False)
 
         if hasattr(self, "log"):
             self.log.info("GUI closed")

--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -25,6 +25,7 @@ from core.process_tracker import (
 )
 from core.profile_manager import active_profile_name
 from gui.browse_dialogs import BrowseDialogsMixin
+from gui.mixins.app_update import AppUpdateMixin
 from gui.mixins.binary_ui import BinaryUIMixin
 from gui.mixins.confirm_dialog import ConfirmDialogMixin
 from gui.mixins.connection import ConnectionMixin
@@ -59,6 +60,7 @@ class ImmichGoGUI(
     ConfirmDialogMixin,
     ExecutionMixin,
     BinaryUIMixin,
+    AppUpdateMixin,
     FormStateMixin,
     PersistenceMixin,
     ProfilesUIMixin,
@@ -261,26 +263,21 @@ class ImmichGoGUI(
                 event.ignore()
                 return
 
-        if not self.has_unsaved_changes():
-            if hasattr(self, "log"):
-                self.log.info("GUI closed")
-            event.accept()
-            return
+        if self.has_unsaved_server_details():
+            reply = self._prompt_save_server_details()
+            if reply == QMessageBox.StandardButton.Cancel:
+                event.ignore()
+                return
+            if reply == QMessageBox.StandardButton.Save:
+                self.save_server_details(show_popup=False)
 
-        reply = QMessageBox.question(
-            self,
-            "Save Configuration",
-            "Save current configuration before closing?",
-            QMessageBox.StandardButton.Save
-            | QMessageBox.StandardButton.Discard
-            | QMessageBox.StandardButton.Cancel,
-            QMessageBox.StandardButton.Save,
-        )
-        if reply == QMessageBox.StandardButton.Cancel:
-            event.ignore()
-            return
-        if reply == QMessageBox.StandardButton.Save:
-            self.save_configuration(show_popup=False)
+        if self.has_unsaved_changes():
+            reply = self._prompt_save_app_settings()
+            if reply == QMessageBox.StandardButton.Cancel:
+                event.ignore()
+                return
+            if reply == QMessageBox.StandardButton.Save:
+                self.save_configuration(show_popup=False)
 
         if hasattr(self, "log"):
             self.log.info("GUI closed")

--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -25,7 +25,6 @@ from core.process_tracker import (
 )
 from core.profile_manager import active_profile_name
 from gui.browse_dialogs import BrowseDialogsMixin
-from gui.mixins.app_update import AppUpdateMixin
 from gui.mixins.binary_ui import BinaryUIMixin
 from gui.mixins.confirm_dialog import ConfirmDialogMixin
 from gui.mixins.connection import ConnectionMixin
@@ -60,7 +59,6 @@ class ImmichGoGUI(
     ConfirmDialogMixin,
     ExecutionMixin,
     BinaryUIMixin,
-    AppUpdateMixin,
     FormStateMixin,
     PersistenceMixin,
     ProfilesUIMixin,

--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -263,21 +263,12 @@ class ImmichGoGUI(
                 event.ignore()
                 return
 
-        if self.has_unsaved_server_details():
-            reply = self._prompt_save_server_details()
-            if reply == QMessageBox.StandardButton.Cancel:
-                event.ignore()
-                return
-            if reply == QMessageBox.StandardButton.Save:
-                self.save_server_details(show_popup=False)
-
-        if self.has_unsaved_changes():
-            reply = self._prompt_save_app_settings()
-            if reply == QMessageBox.StandardButton.Cancel:
-                event.ignore()
-                return
-            if reply == QMessageBox.StandardButton.Save:
-                self.save_configuration(show_popup=False)
+        reply = self._prompt_save_pending_configuration("closing")
+        if reply == QMessageBox.StandardButton.Cancel:
+            event.ignore()
+            return
+        if reply == QMessageBox.StandardButton.Save:
+            self.save_configuration(show_popup=False)
 
         if hasattr(self, "log"):
             self.log.info("GUI closed")

--- a/gui/mixins/menu.py
+++ b/gui/mixins/menu.py
@@ -22,7 +22,7 @@ class MenuMixin:
         menu_bar = self.menuBar()
         file_menu = menu_bar.addMenu("File")
         save_action = QAction("Save Configuration", self)
-        save_action.triggered.connect(lambda: self.save_configuration())
+        save_action.triggered.connect(self._save_from_menu)
         file_menu.addAction(save_action)
         load_action = QAction("Load Configuration", self)
         load_action.triggered.connect(self.load_configuration)

--- a/gui/mixins/persistence.py
+++ b/gui/mixins/persistence.py
@@ -45,7 +45,37 @@ class PersistenceMixin:
                 self._migrate_legacy_qsettings_to_config()
             self.app_config = load_config()
 
-        self.inputs["config"]["server"].setText(self.app_config.server_url)
+        config_inputs = self.inputs["config"]
+        secret_widgets = ("server", "api_key", "admin_api_key")
+        for key in secret_widgets:
+            widget = config_inputs.get(key)
+            if widget is not None:
+                widget.blockSignals(True)
+        try:
+            config_inputs["server"].setText(self.app_config.server_url)
+
+            prof_name = getattr(self.app_config, "profile_name", "default")
+            config_inputs["api_key"].setText(
+                get_secret_with_fallback(
+                    profile_name=prof_name,
+                    key="api_key",
+                    provider=self.app_config.secrets_provider,
+                )
+            )
+
+            if "admin_api_key" in config_inputs:
+                config_inputs["admin_api_key"].setText(
+                    get_secret_with_fallback(
+                        profile_name=prof_name,
+                        key="admin_api_key",
+                        provider=self.app_config.secrets_provider,
+                    )
+                )
+        finally:
+            for key in secret_widgets:
+                widget = config_inputs.get(key)
+                if widget is not None:
+                    widget.blockSignals(False)
 
         if "skip-ssl" in self.inputs["config"]:
             self.inputs["config"]["skip-ssl"].setChecked(self.app_config.skip_ssl)
@@ -61,24 +91,6 @@ class PersistenceMixin:
             )
             if idx >= 0:
                 self.inputs["config"]["secret_provider"].setCurrentIndex(idx)
-
-        prof_name = getattr(self.app_config, "profile_name", "default")
-        self.inputs["config"]["api_key"].setText(
-            get_secret_with_fallback(
-                profile_name=prof_name,
-                key="api_key",
-                provider=self.app_config.secrets_provider,
-            )
-        )
-
-        if "admin_api_key" in self.inputs["config"]:
-            self.inputs["config"]["admin_api_key"].setText(
-                get_secret_with_fallback(
-                    profile_name=prof_name,
-                    key="admin_api_key",
-                    provider=self.app_config.secrets_provider,
-                )
-            )
 
         if "allow_untested_updates" in self.inputs["config"]:
             self.inputs["config"]["allow_untested_updates"].setChecked(
@@ -206,8 +218,27 @@ class PersistenceMixin:
         self._update_secret_status()
         self._mark_server_details_clean()
 
+    def _save_pending_configuration(self, show_popup: bool = False) -> None:
+        """Persist whichever configuration tracks are dirty."""
+        if self.has_unsaved_server_details():
+            self.save_server_details(show_popup=show_popup)
+        if self.has_unsaved_changes():
+            self.save_configuration(show_popup=show_popup)
+
+    def _save_from_menu(self) -> None:
+        """File → Save Configuration: persist server details when dirty, then app settings."""
+        if self.has_unsaved_server_details():
+            self.save_server_details(show_popup=False)
+        self.save_configuration(show_popup=True)
+
     def save_configuration(self, show_popup: bool = True):
-        self.app_config.server_url = self.inputs["config"]["server"].text()
+        prof_name = getattr(self.app_config, "profile_name", "default") or "default"
+        # Server URL is track A; use the widget when that track is dirty, otherwise
+        # keep the on-disk URL so app-settings-only saves cannot wipe credentials.
+        if self.has_unsaved_server_details():
+            self.app_config.server_url = self.inputs["config"]["server"].text()
+        else:
+            self.app_config.server_url = load_config(profile_name=prof_name).server_url
 
         if "skip-ssl" in self.inputs["config"]:
             self.app_config.skip_ssl = self.inputs["config"]["skip-ssl"].isChecked()
@@ -237,11 +268,10 @@ class PersistenceMixin:
 
         self.app_config.advanced_mode = bool(getattr(self, "is_advanced", False))
 
-        cfg_path = default_config_path(
-            getattr(self.app_config, "profile_name", "default")
-        )
+        prof_name = getattr(self.app_config, "profile_name", "default") or "default"
+        cfg_path = default_config_path(prof_name)
         try:
-            save_config(self.app_config)
+            save_config(self.app_config, path=cfg_path, profile_name=prof_name)
         except OSError as exc:
             QMessageBox.critical(
                 cast(QWidget, self),
@@ -251,19 +281,12 @@ class PersistenceMixin:
             return
 
         prof_name = getattr(self.app_config, "profile_name", "default")
-        api_key = self.inputs["config"]["api_key"].text().strip()
         admin_key = (
             self.inputs["config"]["admin_api_key"].text().strip()
             if "admin_api_key" in self.inputs["config"]
             else ""
         )
 
-        res_api = save_secret_with_fallback(
-            profile_name=prof_name,
-            key="api_key",
-            value=api_key,
-            provider=self.app_config.secrets_provider,
-        )
         res_admin = save_secret_with_fallback(
             profile_name=prof_name,
             key="admin_api_key",
@@ -272,8 +295,6 @@ class PersistenceMixin:
         )
 
         msg = f"Configuration saved to:\n{cfg_path}"
-        if res_api.message:
-            msg += f"\n\nNote (API Key): {res_api.message}"
         if res_admin.message:
             msg += f"\n\nNote (Admin Key): {res_admin.message}"
 

--- a/gui/mixins/persistence.py
+++ b/gui/mixins/persistence.py
@@ -49,6 +49,11 @@ class PersistenceMixin:
         if "skip-ssl" in self.inputs["config"]:
             self.inputs["config"]["skip-ssl"].setChecked(self.app_config.skip_ssl)
 
+        if "client_timeout_minutes" in self.inputs["config"]:
+            self.inputs["config"]["client_timeout_minutes"].setValue(
+                self.app_config.client_timeout_minutes
+            )
+
         if "secret_provider" in self.inputs["config"]:
             idx = self.inputs["config"]["secret_provider"].findData(
                 self.app_config.secrets_provider
@@ -84,8 +89,6 @@ class PersistenceMixin:
                 self.app_config.preferred_terminal
             )
 
-        self.apply_form_state(self.app_config.form_state)
-
         self.theme_mode = normalize_theme_mode(self.app_config.theme_mode)
 
         if hasattr(self, "theme_mode_combo"):
@@ -103,17 +106,29 @@ class PersistenceMixin:
         self.update_window_title()
         self._update_secret_status()
         self._mark_configuration_clean()
+        self._mark_server_details_clean()
 
-    def _collect_persisted_state(self) -> dict:
-        """Snapshot of widget state that save_configuration would persist."""
+    def _collect_server_snapshot(self) -> dict:
         config_inputs = self.inputs.get("config", {})
-        state = {
+        return {
             "server_url": config_inputs.get("server").text()
             if config_inputs.get("server")
             else "",
+            "api_key": config_inputs.get("api_key").text().strip()
+            if config_inputs.get("api_key")
+            else "",
+        }
+
+    def _collect_persisted_state(self) -> dict:
+        """Snapshot of application settings (track B) saved by save_configuration."""
+        config_inputs = self.inputs.get("config", {})
+        state = {
             "skip_ssl": config_inputs["skip-ssl"].isChecked()
             if config_inputs.get("skip-ssl")
             else False,
+            "client_timeout_minutes": config_inputs["client_timeout_minutes"].value()
+            if config_inputs.get("client_timeout_minutes")
+            else 60,
             "secrets_provider": config_inputs["secret_provider"].currentData()
             if config_inputs.get("secret_provider")
             else "keyring",
@@ -129,13 +144,9 @@ class PersistenceMixin:
             if hasattr(self, "theme_mode_combo")
             else normalize_theme_mode(self.theme_mode),
             "advanced_mode": bool(getattr(self, "is_advanced", False)),
-            "api_key": config_inputs.get("api_key").text().strip()
-            if config_inputs.get("api_key")
-            else "",
             "admin_api_key": config_inputs.get("admin_api_key").text().strip()
             if config_inputs.get("admin_api_key")
             else "",
-            "form_state": self.collect_form_state(),
         }
         if state["secrets_provider"] is None:
             state["secrets_provider"] = "keyring"
@@ -144,16 +155,66 @@ class PersistenceMixin:
     def _mark_configuration_clean(self) -> None:
         self._config_clean_snapshot = self._collect_persisted_state()
 
+    def _mark_server_details_clean(self) -> None:
+        self._server_clean_snapshot = self._collect_server_snapshot()
+
     def has_unsaved_changes(self) -> bool:
         if not hasattr(self, "_config_clean_snapshot"):
             return False
         return self._collect_persisted_state() != self._config_clean_snapshot
+
+    def has_unsaved_server_details(self) -> bool:
+        if not hasattr(self, "_server_clean_snapshot"):
+            return False
+        return self._collect_server_snapshot() != self._server_clean_snapshot
+
+    def save_server_details(self, show_popup: bool = True):
+        self.app_config.server_url = self.inputs["config"]["server"].text()
+        cfg_path = default_config_path(
+            getattr(self.app_config, "profile_name", "default")
+        )
+        try:
+            save_config(self.app_config)
+        except OSError as exc:
+            QMessageBox.critical(
+                cast(QWidget, self),
+                "Save Failed",
+                f"Could not write configuration to:\n{cfg_path}\n\n{exc}",
+            )
+            return
+
+        prof_name = getattr(self.app_config, "profile_name", "default")
+        api_key = self.inputs["config"]["api_key"].text().strip()
+        res_api = save_secret_with_fallback(
+            profile_name=prof_name,
+            key="api_key",
+            value=api_key,
+            provider=self.app_config.secrets_provider,
+        )
+
+        if show_popup:
+            msg = "Server connection saved."
+            if res_api.message:
+                msg += f"\n\nNote (API Key): {res_api.message}"
+            QMessageBox.information(
+                cast(QWidget, self),
+                "Saved",
+                msg,
+                QMessageBox.StandardButton.Ok,
+            )
+        self._update_secret_status()
+        self._mark_server_details_clean()
 
     def save_configuration(self, show_popup: bool = True):
         self.app_config.server_url = self.inputs["config"]["server"].text()
 
         if "skip-ssl" in self.inputs["config"]:
             self.app_config.skip_ssl = self.inputs["config"]["skip-ssl"].isChecked()
+
+        if "client_timeout_minutes" in self.inputs["config"]:
+            self.app_config.client_timeout_minutes = self.inputs["config"][
+                "client_timeout_minutes"
+            ].value()
 
         if "secret_provider" in self.inputs["config"]:
             self.app_config.secrets_provider = self.inputs["config"][
@@ -173,7 +234,8 @@ class PersistenceMixin:
         if hasattr(self, "theme_mode_combo"):
             self.app_config.theme_mode = self.theme_mode_combo.currentText()
 
-        self.app_config.form_state = self.collect_form_state()
+        self.app_config.advanced_mode = bool(getattr(self, "is_advanced", False))
+
         cfg_path = default_config_path(
             getattr(self.app_config, "profile_name", "default")
         )
@@ -223,6 +285,7 @@ class PersistenceMixin:
             )
         self._update_secret_status()
         self._mark_configuration_clean()
+        self._mark_server_details_clean()
 
     def _probe_keyring(self) -> bool:
         """One-time check: can we actually talk to the keyring?"""
@@ -256,3 +319,25 @@ class PersistenceMixin:
             self.lbl_secret_status.setStyleSheet("color: #E5C07B;")
         else:
             self.lbl_secret_status.setText("")
+
+    def _prompt_save_server_details(self) -> QMessageBox.StandardButton:
+        return QMessageBox.question(
+            cast(QWidget, self),
+            "Save server connection?",
+            "Server URL or API key changed. Save connection details before closing?",
+            QMessageBox.StandardButton.Save
+            | QMessageBox.StandardButton.Discard
+            | QMessageBox.StandardButton.Cancel,
+            QMessageBox.StandardButton.Save,
+        )
+
+    def _prompt_save_app_settings(self) -> QMessageBox.StandardButton:
+        return QMessageBox.question(
+            cast(QWidget, self),
+            "Save settings?",
+            "Theme, timeout, or other configuration settings changed. Save before closing?",
+            QMessageBox.StandardButton.Save
+            | QMessageBox.StandardButton.Discard
+            | QMessageBox.StandardButton.Cancel,
+            QMessageBox.StandardButton.Save,
+        )

--- a/gui/mixins/persistence.py
+++ b/gui/mixins/persistence.py
@@ -12,6 +12,7 @@ from core import (
     load_config,
     save_config,
     save_secret_with_fallback,
+    save_server_url,
     set_api_key,
 )
 from theme import THEME_SYSTEM, normalize_theme_mode
@@ -169,12 +170,12 @@ class PersistenceMixin:
         return self._collect_server_snapshot() != self._server_clean_snapshot
 
     def save_server_details(self, show_popup: bool = True):
-        self.app_config.server_url = self.inputs["config"]["server"].text()
-        cfg_path = default_config_path(
-            getattr(self.app_config, "profile_name", "default")
-        )
+        server_url = self.inputs["config"]["server"].text()
+        self.app_config.server_url = server_url
+        prof_name = getattr(self.app_config, "profile_name", "default")
+        cfg_path = default_config_path(prof_name)
         try:
-            save_config(self.app_config)
+            save_server_url(server_url, path=cfg_path, profile_name=prof_name)
         except OSError as exc:
             QMessageBox.critical(
                 cast(QWidget, self),
@@ -319,6 +320,41 @@ class PersistenceMixin:
             self.lbl_secret_status.setStyleSheet("color: #E5C07B;")
         else:
             self.lbl_secret_status.setText("")
+
+    def _prompt_save_pending_configuration(
+        self, context: str
+    ) -> QMessageBox.StandardButton | None:
+        """Single save prompt when any configuration track is dirty."""
+        server_dirty = self.has_unsaved_server_details()
+        app_dirty = self.has_unsaved_changes()
+        if not server_dirty and not app_dirty:
+            return None
+
+        if server_dirty and app_dirty:
+            body = (
+                "Server connection and other settings changed. "
+                f"Save before {context}?"
+            )
+        elif server_dirty:
+            body = (
+                "Server URL or API key changed. "
+                f"Save connection details before {context}?"
+            )
+        else:
+            body = (
+                "Theme, timeout, or other settings changed. "
+                f"Save before {context}?"
+            )
+
+        return QMessageBox.question(
+            cast(QWidget, self),
+            "Save configuration?",
+            body,
+            QMessageBox.StandardButton.Save
+            | QMessageBox.StandardButton.Discard
+            | QMessageBox.StandardButton.Cancel,
+            QMessageBox.StandardButton.Save,
+        )
 
     def _prompt_save_server_details(self) -> QMessageBox.StandardButton:
         return QMessageBox.question(

--- a/gui/mixins/profiles_ui.py
+++ b/gui/mixins/profiles_ui.py
@@ -25,7 +25,7 @@ class ProfilesUIMixin:
         if reply == QMessageBox.StandardButton.Cancel:
             return False
         if reply == QMessageBox.StandardButton.Save:
-            self.save_configuration(show_popup=False)
+            self._save_pending_configuration(show_popup=False)
         return True
 
     def switch_profile(self, target_name: str):

--- a/gui/mixins/profiles_ui.py
+++ b/gui/mixins/profiles_ui.py
@@ -19,20 +19,13 @@ class ProfilesUIMixin:
 
     def _prompt_profile_switch_saves(self, active: str) -> bool:
         """Return True to continue switching, False to cancel."""
-        if self.has_unsaved_server_details():
-            reply = self._prompt_save_server_details()
-            if reply == QMessageBox.StandardButton.Cancel:
-                return False
-            if reply == QMessageBox.StandardButton.Save:
-                self.save_server_details(show_popup=False)
-
-        if self.has_unsaved_changes():
-            reply = self._prompt_save_app_settings()
-            if reply == QMessageBox.StandardButton.Cancel:
-                return False
-            if reply == QMessageBox.StandardButton.Save:
-                self.save_configuration(show_popup=False)
-
+        reply = self._prompt_save_pending_configuration("switching profile")
+        if reply is None:
+            return True
+        if reply == QMessageBox.StandardButton.Cancel:
+            return False
+        if reply == QMessageBox.StandardButton.Save:
+            self.save_configuration(show_popup=False)
         return True
 
     def switch_profile(self, target_name: str):

--- a/gui/mixins/profiles_ui.py
+++ b/gui/mixins/profiles_ui.py
@@ -17,27 +17,33 @@ class ProfilesUIMixin:
         active = active_profile_name()
         self.setWindowTitle(f"Immich Go GUI — {active}")
 
+    def _prompt_profile_switch_saves(self, active: str) -> bool:
+        """Return True to continue switching, False to cancel."""
+        if self.has_unsaved_server_details():
+            reply = self._prompt_save_server_details()
+            if reply == QMessageBox.StandardButton.Cancel:
+                return False
+            if reply == QMessageBox.StandardButton.Save:
+                self.save_server_details(show_popup=False)
+
+        if self.has_unsaved_changes():
+            reply = self._prompt_save_app_settings()
+            if reply == QMessageBox.StandardButton.Cancel:
+                return False
+            if reply == QMessageBox.StandardButton.Save:
+                self.save_configuration(show_popup=False)
+
+        return True
+
     def switch_profile(self, target_name: str):
         active = active_profile_name()
         if target_name == active:
             return
 
-        if self.has_unsaved_changes():
-            reply = QMessageBox.question(
-                self,
-                "Switch Profile",
-                f"Save changes to current profile '{active}' before switching?",
-                QMessageBox.StandardButton.Save
-                | QMessageBox.StandardButton.Discard
-                | QMessageBox.StandardButton.Cancel,
-                QMessageBox.StandardButton.Save,
-            )
-
-            if reply == QMessageBox.StandardButton.Cancel:
+        if self.has_unsaved_server_details() or self.has_unsaved_changes():
+            if not self._prompt_profile_switch_saves(active):
                 self.update_profiles_menu()
                 return
-            if reply == QMessageBox.StandardButton.Save:
-                self.save_configuration()
 
         try:
             set_active_profile_name(target_name)

--- a/gui/tabs/config_tab.py
+++ b/gui/tabs/config_tab.py
@@ -6,11 +6,13 @@ from PySide6.QtWidgets import (
     QLabel,
     QLineEdit,
     QPushButton,
+    QSpinBox,
     QVBoxLayout,
     QWidget,
 )
 
 from core import default_secrets_path, load_binary_metadata
+from gui.mixins.app_update import _gui_version
 from gui.widgets import BasePage, Card, ElidingLabel, FormSection
 from theme import THEME_DARK, THEME_LIGHT, THEME_SYSTEM
 
@@ -51,9 +53,29 @@ def build_config_tab(host) -> QWidget:
 
     host._add_ssl_skip_row(form, host.inputs["config"])
 
+    host.client_timeout_spin = QSpinBox()
+    host.client_timeout_spin.setRange(5, 240)
+    host.client_timeout_spin.setSuffix(" min")
+    host.client_timeout_spin.setValue(60)
+    host.inputs["config"]["client_timeout_minutes"] = host.client_timeout_spin
+    form.add_row(
+        "Client Timeout",
+        host.client_timeout_spin,
+        "Low values may cause long uploads or archives to fail. Increase if jobs time out.",
+    )
+
     host.btn_test_connection = QPushButton("Test Connection")
     host.btn_test_connection.clicked.connect(host.on_test_connection_clicked)
-    form.add_row("", host.btn_test_connection)
+    host.btn_save_server_details = QPushButton("Save Server Details")
+    host.btn_save_server_details.clicked.connect(
+        lambda: host.save_server_details(show_popup=True)
+    )
+    conn_btn_row = QHBoxLayout()
+    conn_btn_row.setSpacing(8)
+    conn_btn_row.addWidget(host.btn_test_connection)
+    conn_btn_row.addWidget(host.btn_save_server_details)
+    conn_btn_row.addStretch()
+    form.add_row("", conn_btn_row)
 
     card.layout.addLayout(form)
     page.addWidget(card)
@@ -91,6 +113,26 @@ def build_config_tab(host) -> QWidget:
 
     card_sec.layout.addLayout(sec_form)
     page.addWidget(card_sec)
+
+    card_app = Card("Application")
+    app_row = QHBoxLayout()
+    app_row.setSpacing(16)
+    app_row.setAlignment(Qt.AlignmentFlag.AlignTop)
+    app_info = QVBoxLayout()
+    app_info.setSpacing(2)
+    host.lbl_app_version = QLabel(f"Current Version: {_gui_version()}")
+    host.lbl_app_version.setObjectName("FieldLabel")
+    host.lbl_app_version.setWordWrap(True)
+    host.lbl_app_update_status = QLabel("Check for updates to see status.")
+    host.lbl_app_update_status.setObjectName("AppUpdateStatus")
+    app_info.addWidget(host.lbl_app_version)
+    app_info.addWidget(host.lbl_app_update_status)
+    app_row.addLayout(app_info, 1)
+    host.btn_check_app_updates = QPushButton("Check for Updates")
+    host.btn_check_app_updates.clicked.connect(host.check_for_application_updates)
+    app_row.addWidget(host.btn_check_app_updates, 0, Qt.AlignmentFlag.AlignTop)
+    card_app.layout.addLayout(app_row)
+    page.addWidget(card_app)
 
     card2 = Card("Binary Management")
     row = QHBoxLayout()
@@ -168,6 +210,9 @@ def build_config_tab(host) -> QWidget:
     adv_card.setVisible(False)
     page.addWidget(adv_card)
     host.adv_frames.append(adv_card)
+
+    if hasattr(host, "_init_app_update_ui"):
+        host._init_app_update_ui()
 
     page.addStretch()
     return page

--- a/gui/tabs/config_tab.py
+++ b/gui/tabs/config_tab.py
@@ -12,7 +12,6 @@ from PySide6.QtWidgets import (
 )
 
 from core import default_secrets_path, load_binary_metadata
-from gui.mixins.app_update import _gui_version
 from gui.widgets import BasePage, Card, ElidingLabel, FormSection
 from theme import THEME_DARK, THEME_LIGHT, THEME_SYSTEM
 
@@ -114,26 +113,6 @@ def build_config_tab(host) -> QWidget:
     card_sec.layout.addLayout(sec_form)
     page.addWidget(card_sec)
 
-    card_app = Card("Application")
-    app_row = QHBoxLayout()
-    app_row.setSpacing(16)
-    app_row.setAlignment(Qt.AlignmentFlag.AlignTop)
-    app_info = QVBoxLayout()
-    app_info.setSpacing(2)
-    host.lbl_app_version = QLabel(f"Current Version: {_gui_version()}")
-    host.lbl_app_version.setObjectName("FieldLabel")
-    host.lbl_app_version.setWordWrap(True)
-    host.lbl_app_update_status = QLabel("Check for updates to see status.")
-    host.lbl_app_update_status.setObjectName("AppUpdateStatus")
-    app_info.addWidget(host.lbl_app_version)
-    app_info.addWidget(host.lbl_app_update_status)
-    app_row.addLayout(app_info, 1)
-    host.btn_check_app_updates = QPushButton("Check for Updates")
-    host.btn_check_app_updates.clicked.connect(host.check_for_application_updates)
-    app_row.addWidget(host.btn_check_app_updates, 0, Qt.AlignmentFlag.AlignTop)
-    card_app.layout.addLayout(app_row)
-    page.addWidget(card_app)
-
     card2 = Card("Binary Management")
     row = QHBoxLayout()
     row.setSpacing(16)
@@ -210,9 +189,6 @@ def build_config_tab(host) -> QWidget:
     adv_card.setVisible(False)
     page.addWidget(adv_card)
     host.adv_frames.append(adv_card)
-
-    if hasattr(host, "_init_app_update_ui"):
-        host._init_app_update_ui()
 
     page.addStretch()
     return page

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -58,6 +58,8 @@ def gui(qapp):
             g._conn_test_debounce.timeout.disconnect()
         g._auto_test_connection = lambda: None
         g._mark_configuration_clean()
+        if hasattr(g, "_mark_server_details_clean"):
+            g._mark_server_details_clean()
         yield g
         g._force_close = True
         g.close()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -41,7 +41,6 @@ def gui(qapp):
     """
     with (
         patch.object(ImmichGoGUI, "check_binary_version"),
-        patch.object(ImmichGoGUI, "load_configuration"),
         patch.object(ImmichGoGUI, "_probe_keyring", return_value=True),
         patch("PySide6.QtWidgets.QMessageBox.warning"),
         patch(
@@ -49,7 +48,10 @@ def gui(qapp):
             return_value=QMessageBox.StandardButton.Discard,
         ),
     ):
-        g = ImmichGoGUI()
+        # Only skip load during construction; other tests may instantiate ImmichGoGUI
+        # and need the real load_configuration implementation.
+        with patch.object(ImmichGoGUI, "load_configuration"):
+            g = ImmichGoGUI()
         g.binary_path = "./immich-go"
         # Never fire silent connection tests during the suite — they hit the
         # network with a 4s timeout and dominate wall time when Qt processes events.
@@ -76,6 +78,18 @@ def suppress_qt_dialogs(monkeypatch):
         "PySide6.QtWidgets.QMessageBox.question",
         MagicMock(return_value=QMessageBox.StandardButton.Discard),
     )
+
+
+@pytest.fixture(autouse=True)
+def _isolate_user_config(tmp_path, monkeypatch):
+    """Keep tests off the developer's real ~/.config/immich-go-gui directory."""
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg-config"))
+    monkeypatch.delenv("IMMICH_GO_GUI_CONFIG", raising=False)
+    from core.profile_manager import clear_profiles_cache
+
+    clear_profiles_cache()
+    yield
+    clear_profiles_cache()
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -52,6 +52,11 @@ value = 45
     assert cfg.schema_version == 3
     assert cfg.client_timeout_minutes == 45
 
+    data = tomllib.loads(cfg_path.read_text(encoding="utf-8"))
+    assert data["schema_version"] == 3
+    assert data["server"]["client_timeout_minutes"] == 45
+    assert "form_state" not in data
+
 
 def test_save_config_schema_v3_without_form_state(tmp_path, monkeypatch):
     monkeypatch.setenv("IMMICH_GO_GUI_CONFIG", str(tmp_path / "config.toml"))

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -1,6 +1,9 @@
 """Unit tests for configuration loading and quarantine behavior."""
 
-from core.config_manager import get_config_load_warning, load_config
+import tomllib
+
+from core.config_manager import get_config_load_warning, load_config, save_config
+from core.models import AppConfig
 
 
 def test_corrupt_config_quarantined_and_defaults_loaded(tmp_path, monkeypatch):
@@ -19,3 +22,44 @@ def test_corrupt_config_quarantined_and_defaults_loaded(tmp_path, monkeypatch):
     corrupt_files = list(tmp_path.glob("config.toml.corrupt-*"))
     assert len(corrupt_files) == 1
     assert not cfg_path.exists()
+
+
+def test_schema_v2_migrates_client_timeout_from_form_state(tmp_path, monkeypatch):
+    monkeypatch.setenv("IMMICH_GO_GUI_CONFIG", str(tmp_path / "config.toml"))
+    cfg_path = tmp_path / "config.toml"
+    cfg_path.write_text(
+        """
+schema_version = 2
+
+[general]
+theme = "system"
+
+[server]
+url = "http://localhost:2283"
+
+[secrets]
+provider = "keyring"
+
+[form_state.advanced."upload-folder"]
+[form_state.advanced."upload-folder"."client-timeout"]
+enabled = true
+value = 45
+""".strip(),
+        encoding="utf-8",
+    )
+
+    cfg = load_config()
+    assert cfg.schema_version == 3
+    assert cfg.client_timeout_minutes == 45
+
+
+def test_save_config_schema_v3_without_form_state(tmp_path, monkeypatch):
+    monkeypatch.setenv("IMMICH_GO_GUI_CONFIG", str(tmp_path / "config.toml"))
+    cfg = AppConfig()
+    cfg.client_timeout_minutes = 90
+    save_config(cfg)
+
+    data = tomllib.loads((tmp_path / "config.toml").read_text(encoding="utf-8"))
+    assert data["schema_version"] == 3
+    assert data["server"]["client_timeout_minutes"] == 90
+    assert "form_state" not in data

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -1,5 +1,6 @@
 from unittest.mock import MagicMock, patch
 
+from PySide6.QtWidgets import QMessageBox
 
 from core.config_manager import (
     SecretStore,
@@ -150,6 +151,84 @@ def test_save_marks_configuration_clean(gui, monkeypatch):
     assert gui.has_unsaved_changes() is True
     gui.save_configuration(show_popup=False)
     assert gui.has_unsaved_changes() is False
+
+
+def test_save_configuration_preserves_server_credentials_when_widgets_empty(
+    tmp_path, monkeypatch, gui
+):
+    """Regression: app-settings save must not wipe URL/API key from empty widgets."""
+    cfg_file = tmp_path / "config.toml"
+    secrets_file = tmp_path / "secrets.toml"
+    monkeypatch.setenv("IMMICH_GO_GUI_CONFIG", str(cfg_file))
+    monkeypatch.setattr(
+        "core.config_manager.default_secrets_path", lambda *_a, **_k: secrets_file
+    )
+
+    cfg = AppConfig()
+    cfg.server_url = "http://persisted:2283"
+    save_config(cfg, path=cfg_file)
+    save_secret_with_fallback(
+        profile_name="default",
+        key="api_key",
+        value="persisted-key",
+        provider="keyring",
+        secrets_path=secrets_file,
+    )
+
+    gui.app_config = load_config()
+    gui.inputs["config"]["server"].clear()
+    gui.inputs["config"]["api_key"].clear()
+    gui._mark_configuration_clean()
+    gui._mark_server_details_clean()
+    gui.inputs["config"]["skip-ssl"].setChecked(True)
+
+    gui.save_configuration(show_popup=False)
+
+    loaded = load_config()
+    assert loaded.server_url == "http://persisted:2283"
+    assert loaded.skip_ssl is True
+    assert (
+        get_secret_with_fallback(
+            profile_name="default",
+            key="api_key",
+            provider="keyring",
+            secrets_path=secrets_file,
+        )
+        == "persisted-key"
+    )
+
+
+def test_close_event_server_dirty_calls_save_server_details(gui, monkeypatch):
+    from PySide6.QtGui import QCloseEvent
+
+    calls = {"server": 0, "config": 0}
+
+    monkeypatch.setattr(
+        gui,
+        "_prompt_save_pending_configuration",
+        lambda context: QMessageBox.StandardButton.Save,
+    )
+    monkeypatch.setattr(
+        gui,
+        "save_server_details",
+        lambda show_popup=True: calls.__setitem__("server", calls["server"] + 1),
+    )
+    monkeypatch.setattr(
+        gui,
+        "save_configuration",
+        lambda show_popup=True: calls.__setitem__("config", calls["config"] + 1),
+    )
+    monkeypatch.setattr("gui.main_window.scan_locks", list)
+    gui._mark_configuration_clean()
+    gui._mark_server_details_clean()
+    gui.inputs["config"]["server"].setText("http://changed:2283")
+
+    event = QCloseEvent()
+    gui.closeEvent(event)
+
+    assert calls["server"] == 1
+    assert calls["config"] == 0
+    assert event.isAccepted()
 
 
 def test_config_roundtrip(tmp_path, monkeypatch):
@@ -335,7 +414,6 @@ def test_legacy_root_config_migrated_when_profiles_dir_exists(tmp_path, monkeypa
     (base / "profiles" / "default").mkdir(parents=True)
 
     monkeypatch.setattr("core.config_manager.default_config_dir", lambda: base)
-    monkeypatch.setattr("core.profile_manager.default_config_dir", lambda: base)
     clear_profiles_cache()
 
     migrate_single_config_to_default()
@@ -352,8 +430,9 @@ def test_save_config_uses_profile_path_without_env_override(tmp_path, monkeypatc
     from core.profile_manager import clear_profiles_cache, profile_config_path
 
     base = tmp_path / "immich-go-gui"
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg-config"))
+    monkeypatch.delenv("IMMICH_GO_GUI_CONFIG", raising=False)
     monkeypatch.setattr("core.config_manager.default_config_dir", lambda: base)
-    monkeypatch.setattr("core.profile_manager.default_config_dir", lambda: base)
     clear_profiles_cache()
 
     cfg = AppConfig()
@@ -362,6 +441,84 @@ def test_save_config_uses_profile_path_without_env_override(tmp_path, monkeypatc
     save_config(cfg)
 
     path = profile_config_path("default")
+    assert path == base / "profiles" / "default" / "config.toml"
     assert path.exists()
     loaded = load_config(path)
     assert loaded.server_url == "http://saved:2283"
+
+
+def test_linux_xdg_save_server_details_roundtrip(tmp_path, monkeypatch):
+    """Regression: GUI save must persist server URL under Linux XDG profile paths."""
+    from unittest.mock import patch
+
+    from core.profile_manager import clear_profiles_cache, profile_config_path
+    from gui import ImmichGoGUI
+
+    xdg = tmp_path / "xdg-config"
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(xdg))
+    monkeypatch.delenv("IMMICH_GO_GUI_CONFIG", raising=False)
+    clear_profiles_cache()
+
+    with (
+        patch.object(ImmichGoGUI, "check_binary_version"),
+        patch.object(ImmichGoGUI, "_probe_keyring", return_value=True),
+        patch("PySide6.QtWidgets.QMessageBox.warning"),
+    ):
+        gui = ImmichGoGUI()
+        gui.inputs["config"]["server"].setText("http://linux-host:2283")
+        gui.inputs["config"]["api_key"].setText("roundtrip-key")
+        gui.save_server_details(show_popup=False)
+        gui._force_close = True
+        gui.close()
+
+    cfg_path = profile_config_path("default")
+    assert cfg_path == xdg / "immich-go-gui" / "profiles" / "default" / "config.toml"
+    assert load_config(cfg_path).server_url == "http://linux-host:2283"
+
+    clear_profiles_cache()
+    with (
+        patch.object(ImmichGoGUI, "check_binary_version"),
+        patch.object(ImmichGoGUI, "_probe_keyring", return_value=True),
+        patch("PySide6.QtWidgets.QMessageBox.warning"),
+        patch(
+            "gui.mixins.persistence.get_secret_with_fallback",
+            return_value="roundtrip-key",
+        ),
+    ):
+        gui2 = ImmichGoGUI()
+        gui2.load_configuration()
+
+    assert gui2.inputs["config"]["server"].text() == "http://linux-host:2283"
+    assert gui2.inputs["config"]["api_key"].text() == "roundtrip-key"
+    gui2._force_close = True
+    gui2.close()
+
+
+def test_linux_xdg_save_configuration_roundtrip(tmp_path, monkeypatch):
+    """Regression: File → Save persists server URL via save_server_details when dirty."""
+    from unittest.mock import patch
+
+    from core.profile_manager import clear_profiles_cache, profile_config_path
+    from gui import ImmichGoGUI
+
+    xdg = tmp_path / "xdg-config"
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(xdg))
+    monkeypatch.delenv("IMMICH_GO_GUI_CONFIG", raising=False)
+    clear_profiles_cache()
+
+    with (
+        patch.object(ImmichGoGUI, "check_binary_version"),
+        patch.object(ImmichGoGUI, "_probe_keyring", return_value=True),
+        patch("PySide6.QtWidgets.QMessageBox.warning"),
+        patch("PySide6.QtWidgets.QMessageBox.information"),
+    ):
+        gui = ImmichGoGUI()
+        gui._mark_configuration_clean()
+        gui._mark_server_details_clean()
+        gui.inputs["config"]["server"].setText("http://linux-save-config:2283")
+        gui._save_from_menu()
+        gui._force_close = True
+        gui.close()
+
+    cfg_path = profile_config_path("default")
+    assert load_config(cfg_path).server_url == "http://linux-save-config:2283"

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -36,13 +36,36 @@ def test_secret_store_migration():
 def test_has_unsaved_changes_detects_widget_edits(gui):
     gui._mark_configuration_clean()
     assert gui.has_unsaved_changes() is False
-    gui.inputs["config"]["server"].setText("http://edited:2283")
+    gui.inputs["config"]["skip-ssl"].setChecked(True)
     assert gui.has_unsaved_changes() is True
+
+
+def test_has_unsaved_changes_ignores_server_url(gui):
+    gui._mark_configuration_clean()
+    gui._mark_server_details_clean()
+    gui.inputs["config"]["server"].setText("http://edited:2283")
+    assert gui.has_unsaved_changes() is False
+    assert gui.has_unsaved_server_details() is True
+
+
+def test_has_unsaved_server_details_detects_api_key(gui):
+    gui._mark_server_details_clean()
+    gui.inputs["config"]["api_key"].setText("new-secret-key")
+    assert gui.has_unsaved_server_details() is True
+
+
+def test_save_server_details_marks_clean(gui, monkeypatch):
+    gui._mark_server_details_clean()
+    gui.inputs["config"]["server"].setText("http://edited:2283")
+    assert gui.has_unsaved_server_details() is True
+    gui.save_server_details(show_popup=False)
+    assert gui.has_unsaved_server_details() is False
 
 
 def test_save_marks_configuration_clean(gui, monkeypatch):
     gui._mark_configuration_clean()
-    gui.inputs["config"]["server"].setText("http://edited:2283")
+    gui._mark_server_details_clean()
+    gui.inputs["config"]["skip-ssl"].setChecked(True)
     assert gui.has_unsaved_changes() is True
     gui.save_configuration(show_popup=False)
     assert gui.has_unsaved_changes() is False

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -7,6 +7,7 @@ from core.config_manager import (
     load_config,
     save_config,
     save_secret_with_fallback,
+    save_server_url,
 )
 from core.models import AppConfig
 
@@ -60,6 +61,86 @@ def test_save_server_details_marks_clean(gui, monkeypatch):
     assert gui.has_unsaved_server_details() is True
     gui.save_server_details(show_popup=False)
     assert gui.has_unsaved_server_details() is False
+
+
+def test_unified_save_prompt_both_tracks_dirty(gui, monkeypatch):
+    from PySide6.QtWidgets import QMessageBox
+
+    captured = {}
+
+    def fake_question(widget, title, body, buttons, default):
+        captured["title"] = title
+        captured["body"] = body
+        return QMessageBox.StandardButton.Save
+
+    monkeypatch.setattr("gui.mixins.persistence.QMessageBox.question", fake_question)
+    gui._mark_configuration_clean()
+    gui._mark_server_details_clean()
+    gui.inputs["config"]["api_key"].setText("changed-key")
+    gui.inputs["config"]["client_timeout_minutes"].setValue(120)
+
+    reply = gui._prompt_save_pending_configuration("closing")
+    assert reply == QMessageBox.StandardButton.Save
+    assert captured["title"] == "Save configuration?"
+    assert "Server connection and other settings" in captured["body"]
+
+
+def test_save_server_details_preserves_other_server_fields(tmp_path, monkeypatch, gui):
+    cfg_file = tmp_path / "config.toml"
+    monkeypatch.setenv("IMMICH_GO_GUI_CONFIG", str(cfg_file))
+    cfg_file.write_text(
+        """
+schema_version = 3
+
+[general]
+theme = "system"
+
+[server]
+url = "http://original:2283"
+skip_ssl = true
+client_timeout_minutes = 90
+
+[secrets]
+provider = "keyring"
+""".strip(),
+        encoding="utf-8",
+    )
+
+    gui.load_configuration()
+    gui._mark_server_details_clean()
+    gui.inputs["config"]["client_timeout_minutes"].setValue(30)
+    gui.inputs["config"]["skip-ssl"].setChecked(False)
+    gui.inputs["config"]["api_key"].setText("new-api-key")
+
+    gui.save_server_details(show_popup=False)
+
+    loaded = load_config()
+    assert loaded.server_url == gui.inputs["config"]["server"].text()
+    assert loaded.skip_ssl is True
+    assert loaded.client_timeout_minutes == 90
+
+
+def test_save_server_url_merge_write(tmp_path, monkeypatch):
+    cfg_file = tmp_path / "config.toml"
+    monkeypatch.setenv("IMMICH_GO_GUI_CONFIG", str(cfg_file))
+    cfg_file.write_text(
+        """
+schema_version = 3
+
+[server]
+url = "http://old:2283"
+skip_ssl = true
+client_timeout_minutes = 75
+""".strip(),
+        encoding="utf-8",
+    )
+
+    save_server_url("http://new:2283", path=cfg_file)
+
+    loaded = load_config()
+    assert loaded.server_url == "http://new:2283"
+    assert loaded.skip_ssl is True
+    assert loaded.client_timeout_minutes == 75
 
 
 def test_save_marks_configuration_clean(gui, monkeypatch):

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -451,31 +451,13 @@ def test_linux_xdg_save_server_details_roundtrip(tmp_path, monkeypatch):
     """Regression: GUI save must persist server URL under Linux XDG profile paths."""
     from unittest.mock import patch
 
-    from core.profile_manager import clear_profiles_cache, profile_config_path
+    from core.profile_manager import profile_config_path
     from gui import ImmichGoGUI
 
     xdg = tmp_path / "xdg-config"
     monkeypatch.setenv("XDG_CONFIG_HOME", str(xdg))
     monkeypatch.delenv("IMMICH_GO_GUI_CONFIG", raising=False)
-    clear_profiles_cache()
 
-    with (
-        patch.object(ImmichGoGUI, "check_binary_version"),
-        patch.object(ImmichGoGUI, "_probe_keyring", return_value=True),
-        patch("PySide6.QtWidgets.QMessageBox.warning"),
-    ):
-        gui = ImmichGoGUI()
-        gui.inputs["config"]["server"].setText("http://linux-host:2283")
-        gui.inputs["config"]["api_key"].setText("roundtrip-key")
-        gui.save_server_details(show_popup=False)
-        gui._force_close = True
-        gui.close()
-
-    cfg_path = profile_config_path("default")
-    assert cfg_path == xdg / "immich-go-gui" / "profiles" / "default" / "config.toml"
-    assert load_config(cfg_path).server_url == "http://linux-host:2283"
-
-    clear_profiles_cache()
     with (
         patch.object(ImmichGoGUI, "check_binary_version"),
         patch.object(ImmichGoGUI, "_probe_keyring", return_value=True),
@@ -485,13 +467,21 @@ def test_linux_xdg_save_server_details_roundtrip(tmp_path, monkeypatch):
             return_value="roundtrip-key",
         ),
     ):
-        gui2 = ImmichGoGUI()
-        gui2.load_configuration()
+        gui = ImmichGoGUI()
+        gui.inputs["config"]["server"].setText("http://linux-host:2283")
+        gui.inputs["config"]["api_key"].setText("roundtrip-key")
+        gui.save_server_details(show_popup=False)
 
-    assert gui2.inputs["config"]["server"].text() == "http://linux-host:2283"
-    assert gui2.inputs["config"]["api_key"].text() == "roundtrip-key"
-    gui2._force_close = True
-    gui2.close()
+        cfg_path = profile_config_path("default")
+        assert cfg_path == xdg / "immich-go-gui" / "profiles" / "default" / "config.toml"
+        assert load_config(cfg_path).server_url == "http://linux-host:2283"
+
+        gui.inputs["config"]["server"].clear()
+        gui.inputs["config"]["api_key"].clear()
+        gui.load_configuration()
+
+        assert gui.inputs["config"]["server"].text() == "http://linux-host:2283"
+        assert gui.inputs["config"]["api_key"].text() == "roundtrip-key"
 
 
 def test_linux_xdg_save_configuration_roundtrip(tmp_path, monkeypatch):

--- a/tests/test_profiles_ui.py
+++ b/tests/test_profiles_ui.py
@@ -68,8 +68,8 @@ def test_profile_switch_save_discard_cancel(gui, monkeypatch):
     monkeypatch.setattr(gui, "_prompt_save_pending_configuration", fake_prompt)
     monkeypatch.setattr(
         gui,
-        "save_configuration",
-        lambda show_popup=True: actions.append("saved_config"),
+        "_save_pending_configuration",
+        lambda show_popup=False: actions.append("saved_pending"),
     )
     monkeypatch.setattr(
         "gui.mixins.profiles_ui.set_active_profile_name",
@@ -93,7 +93,7 @@ def test_profile_switch_save_discard_cancel(gui, monkeypatch):
     gui._mark_configuration_clean()
     gui._mark_server_details_clean()
     gui.switch_profile("work")
-    assert "saved_config" not in actions
+    assert "saved_pending" not in actions
     assert "active:work" in actions
     assert "loaded" in actions
 
@@ -104,7 +104,7 @@ def test_profile_switch_save_discard_cancel(gui, monkeypatch):
     gui._mark_server_details_clean()
     gui.inputs["config"]["server"].setText("http://changed:2283")
     gui.switch_profile("home")
-    assert "saved_config" not in actions
+    assert "saved_pending" not in actions
     assert "active:home" in actions
     assert "loaded" in actions
 
@@ -115,7 +115,7 @@ def test_profile_switch_save_discard_cancel(gui, monkeypatch):
     gui._mark_server_details_clean()
     gui.inputs["config"]["server"].setText("http://save-me:2283")
     gui.switch_profile("office")
-    assert "saved_config" in actions
+    assert "saved_pending" in actions
     assert "active:office" in actions
 
 
@@ -130,8 +130,8 @@ def test_profile_switch_both_tracks_dirty_single_prompt(gui, monkeypatch):
     monkeypatch.setattr(gui, "_prompt_save_pending_configuration", fake_prompt)
     monkeypatch.setattr(
         gui,
-        "save_configuration",
-        lambda show_popup=True: saved.__setitem__("n", saved["n"] + 1),
+        "_save_pending_configuration",
+        lambda show_popup=False: saved.__setitem__("n", saved["n"] + 1),
     )
     monkeypatch.setattr("gui.mixins.profiles_ui.set_active_profile_name", lambda _: None)
     monkeypatch.setattr(gui, "load_configuration", lambda: None)

--- a/tests/test_profiles_ui.py
+++ b/tests/test_profiles_ui.py
@@ -61,21 +61,11 @@ def test_profile_switch_save_discard_cancel(gui, monkeypatch):
     actions = []
     prompts = []
 
-    def fake_prompt_server():
-        prompts.append("server")
+    def fake_prompt(context):
+        prompts.append(context)
         return actions[-1]
 
-    def fake_prompt_app():
-        prompts.append("app")
-        return actions[-1]
-
-    monkeypatch.setattr(gui, "_prompt_save_server_details", fake_prompt_server)
-    monkeypatch.setattr(gui, "_prompt_save_app_settings", fake_prompt_app)
-    monkeypatch.setattr(
-        gui,
-        "save_server_details",
-        lambda show_popup=True: actions.append("saved_server"),
-    )
+    monkeypatch.setattr(gui, "_prompt_save_pending_configuration", fake_prompt)
     monkeypatch.setattr(
         gui,
         "save_configuration",
@@ -96,14 +86,13 @@ def test_profile_switch_save_discard_cancel(gui, monkeypatch):
     gui.inputs["config"]["server"].setText("http://changed:2283")
     gui.switch_profile("work")
     assert "active:work" not in actions
-    assert prompts == ["server"]
+    assert prompts == ["switching profile"]
 
     actions.clear()
     prompts.clear()
     gui._mark_configuration_clean()
     gui._mark_server_details_clean()
     gui.switch_profile("work")
-    assert "saved_server" not in actions
     assert "saved_config" not in actions
     assert "active:work" in actions
     assert "loaded" in actions
@@ -115,7 +104,7 @@ def test_profile_switch_save_discard_cancel(gui, monkeypatch):
     gui._mark_server_details_clean()
     gui.inputs["config"]["server"].setText("http://changed:2283")
     gui.switch_profile("home")
-    assert "saved_server" not in actions
+    assert "saved_config" not in actions
     assert "active:home" in actions
     assert "loaded" in actions
 
@@ -126,5 +115,35 @@ def test_profile_switch_save_discard_cancel(gui, monkeypatch):
     gui._mark_server_details_clean()
     gui.inputs["config"]["server"].setText("http://save-me:2283")
     gui.switch_profile("office")
-    assert "saved_server" in actions
+    assert "saved_config" in actions
     assert "active:office" in actions
+
+
+def test_profile_switch_both_tracks_dirty_single_prompt(gui, monkeypatch):
+    prompts = []
+
+    def fake_prompt(context):
+        prompts.append(context)
+        return QMessageBox.StandardButton.Save
+
+    saved = {"n": 0}
+    monkeypatch.setattr(gui, "_prompt_save_pending_configuration", fake_prompt)
+    monkeypatch.setattr(
+        gui,
+        "save_configuration",
+        lambda show_popup=True: saved.__setitem__("n", saved["n"] + 1),
+    )
+    monkeypatch.setattr("gui.mixins.profiles_ui.set_active_profile_name", lambda _: None)
+    monkeypatch.setattr(gui, "load_configuration", lambda: None)
+    monkeypatch.setattr(gui, "update_profiles_menu", lambda: None)
+    monkeypatch.setattr(gui, "update_window_title", lambda: None)
+    monkeypatch.setattr("gui.mixins.profiles_ui.active_profile_name", lambda: "default")
+
+    gui._mark_configuration_clean()
+    gui._mark_server_details_clean()
+    gui.inputs["config"]["api_key"].setText("new-key")
+    gui.inputs["config"]["skip-ssl"].setChecked(not gui.inputs["config"]["skip-ssl"].isChecked())
+
+    gui.switch_profile("work")
+    assert len(prompts) == 1
+    assert saved["n"] == 1

--- a/tests/test_profiles_ui.py
+++ b/tests/test_profiles_ui.py
@@ -59,13 +59,27 @@ def test_profile_name_validation():
 
 def test_profile_switch_save_discard_cancel(gui, monkeypatch):
     actions = []
+    prompts = []
 
-    def fake_question(*args, **kwargs):
+    def fake_prompt_server():
+        prompts.append("server")
         return actions[-1]
 
-    monkeypatch.setattr("PySide6.QtWidgets.QMessageBox.question", fake_question)
+    def fake_prompt_app():
+        prompts.append("app")
+        return actions[-1]
+
+    monkeypatch.setattr(gui, "_prompt_save_server_details", fake_prompt_server)
+    monkeypatch.setattr(gui, "_prompt_save_app_settings", fake_prompt_app)
     monkeypatch.setattr(
-        gui, "save_configuration", lambda show_popup=True: actions.append("saved")
+        gui,
+        "save_server_details",
+        lambda show_popup=True: actions.append("saved_server"),
+    )
+    monkeypatch.setattr(
+        gui,
+        "save_configuration",
+        lambda show_popup=True: actions.append("saved_config"),
     )
     monkeypatch.setattr(
         "gui.mixins.profiles_ui.set_active_profile_name",
@@ -78,30 +92,39 @@ def test_profile_switch_save_discard_cancel(gui, monkeypatch):
 
     actions.append(QMessageBox.StandardButton.Cancel)
     gui._mark_configuration_clean()
+    gui._mark_server_details_clean()
     gui.inputs["config"]["server"].setText("http://changed:2283")
     gui.switch_profile("work")
     assert "active:work" not in actions
+    assert prompts == ["server"]
 
     actions.clear()
+    prompts.clear()
     gui._mark_configuration_clean()
+    gui._mark_server_details_clean()
     gui.switch_profile("work")
-    assert "saved" not in actions
+    assert "saved_server" not in actions
+    assert "saved_config" not in actions
     assert "active:work" in actions
     assert "loaded" in actions
 
     actions.clear()
+    prompts.clear()
     actions.append(QMessageBox.StandardButton.Discard)
     gui._mark_configuration_clean()
+    gui._mark_server_details_clean()
     gui.inputs["config"]["server"].setText("http://changed:2283")
     gui.switch_profile("home")
-    assert "saved" not in actions
+    assert "saved_server" not in actions
     assert "active:home" in actions
     assert "loaded" in actions
 
     actions.clear()
+    prompts.clear()
     actions.append(QMessageBox.StandardButton.Save)
     gui._mark_configuration_clean()
+    gui._mark_server_details_clean()
     gui.inputs["config"]["server"].setText("http://save-me:2283")
     gui.switch_profile("office")
-    assert "saved" in actions
+    assert "saved_server" in actions
     assert "active:office" in actions

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -28,25 +28,39 @@ def test_running_process_boolean_state(gui):
 def test_close_event_save_prompt(gui, monkeypatch):
     from PySide6.QtGui import QCloseEvent
 
-    calls = {"save": 0, "question": 0}
+    calls = {"save_server": 0, "save_config": 0, "question": 0}
 
     def fake_question(*args, **kwargs):
         calls["question"] += 1
-        return QMessageBox.StandardButton.Save
+        title = args[1] if len(args) > 1 else kwargs.get("title", "")
+        if "server connection" in str(title).lower():
+            return QMessageBox.StandardButton.Save
+        return QMessageBox.StandardButton.Discard
 
     monkeypatch.setattr("PySide6.QtWidgets.QMessageBox.question", fake_question)
     monkeypatch.setattr(
         gui,
+        "save_server_details",
+        lambda show_popup=True: calls.__setitem__(
+            "save_server", calls["save_server"] + 1
+        ),
+    )
+    monkeypatch.setattr(
+        gui,
         "save_configuration",
-        lambda show_popup=True: calls.__setitem__("save", calls["save"] + 1),
+        lambda show_popup=True: calls.__setitem__(
+            "save_config", calls["save_config"] + 1
+        ),
     )
     monkeypatch.setattr("gui.main_window.scan_locks", list)
     gui._mark_configuration_clean()
+    gui._mark_server_details_clean()
     gui.inputs["config"]["server"].setText("http://changed:2283")
     event = QCloseEvent()
     gui.closeEvent(event)
     assert calls["question"] == 1
-    assert calls["save"] == 1
+    assert calls["save_server"] == 1
+    assert calls["save_config"] == 0
     assert event.isAccepted()
 
 
@@ -59,11 +73,17 @@ def test_close_event_cancel_ignores(gui, monkeypatch):
     )
     monkeypatch.setattr(
         gui,
+        "save_server_details",
+        lambda show_popup=True: (_ for _ in ()).throw(AssertionError("save")),
+    )
+    monkeypatch.setattr(
+        gui,
         "save_configuration",
         lambda show_popup=True: (_ for _ in ()).throw(AssertionError("save")),
     )
     monkeypatch.setattr("gui.main_window.scan_locks", list)
     gui._mark_configuration_clean()
+    gui._mark_server_details_clean()
     gui.inputs["config"]["server"].setText("http://changed:2283")
     event = QCloseEvent()
     gui.closeEvent(event)
@@ -73,7 +93,7 @@ def test_close_event_cancel_ignores(gui, monkeypatch):
 def test_close_event_discard_no_save(gui, monkeypatch):
     from PySide6.QtGui import QCloseEvent
 
-    calls = {"save": 0, "question": 0}
+    calls = {"save_server": 0, "save_config": 0, "question": 0}
 
     def fake_question(*args, **kwargs):
         calls["question"] += 1
@@ -82,16 +102,27 @@ def test_close_event_discard_no_save(gui, monkeypatch):
     monkeypatch.setattr("PySide6.QtWidgets.QMessageBox.question", fake_question)
     monkeypatch.setattr(
         gui,
+        "save_server_details",
+        lambda show_popup=True: calls.__setitem__(
+            "save_server", calls["save_server"] + 1
+        ),
+    )
+    monkeypatch.setattr(
+        gui,
         "save_configuration",
-        lambda show_popup=True: calls.__setitem__("save", calls["save"] + 1),
+        lambda show_popup=True: calls.__setitem__(
+            "save_config", calls["save_config"] + 1
+        ),
     )
     monkeypatch.setattr("gui.main_window.scan_locks", list)
     gui._mark_configuration_clean()
+    gui._mark_server_details_clean()
     gui.inputs["config"]["server"].setText("http://changed:2283")
     event = QCloseEvent()
     gui.closeEvent(event)
     assert calls["question"] == 1
-    assert calls["save"] == 0
+    assert calls["save_server"] == 0
+    assert calls["save_config"] == 0
     assert event.isAccepted()
 
 

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -28,23 +28,13 @@ def test_running_process_boolean_state(gui):
 def test_close_event_save_prompt(gui, monkeypatch):
     from PySide6.QtGui import QCloseEvent
 
-    calls = {"save_server": 0, "save_config": 0, "question": 0}
+    calls = {"save_config": 0, "prompt": 0}
 
-    def fake_question(*args, **kwargs):
-        calls["question"] += 1
-        title = args[1] if len(args) > 1 else kwargs.get("title", "")
-        if "server connection" in str(title).lower():
-            return QMessageBox.StandardButton.Save
-        return QMessageBox.StandardButton.Discard
+    def fake_prompt(context):
+        calls["prompt"] += 1
+        return QMessageBox.StandardButton.Save
 
-    monkeypatch.setattr("PySide6.QtWidgets.QMessageBox.question", fake_question)
-    monkeypatch.setattr(
-        gui,
-        "save_server_details",
-        lambda show_popup=True: calls.__setitem__(
-            "save_server", calls["save_server"] + 1
-        ),
-    )
+    monkeypatch.setattr(gui, "_prompt_save_pending_configuration", fake_prompt)
     monkeypatch.setattr(
         gui,
         "save_configuration",
@@ -58,9 +48,37 @@ def test_close_event_save_prompt(gui, monkeypatch):
     gui.inputs["config"]["server"].setText("http://changed:2283")
     event = QCloseEvent()
     gui.closeEvent(event)
-    assert calls["question"] == 1
-    assert calls["save_server"] == 1
-    assert calls["save_config"] == 0
+    assert calls["prompt"] == 1
+    assert calls["save_config"] == 1
+    assert event.isAccepted()
+
+
+def test_close_event_both_tracks_dirty_single_prompt(gui, monkeypatch):
+    from PySide6.QtGui import QCloseEvent
+
+    calls = {"save_config": 0, "prompt": 0}
+
+    def fake_prompt(context):
+        calls["prompt"] += 1
+        return QMessageBox.StandardButton.Save
+
+    monkeypatch.setattr(gui, "_prompt_save_pending_configuration", fake_prompt)
+    monkeypatch.setattr(
+        gui,
+        "save_configuration",
+        lambda show_popup=True: calls.__setitem__(
+            "save_config", calls["save_config"] + 1
+        ),
+    )
+    monkeypatch.setattr("gui.main_window.scan_locks", list)
+    gui._mark_configuration_clean()
+    gui._mark_server_details_clean()
+    gui.inputs["config"]["api_key"].setText("new-key")
+    gui.inputs["config"]["skip-ssl"].setChecked(not gui.inputs["config"]["skip-ssl"].isChecked())
+    event = QCloseEvent()
+    gui.closeEvent(event)
+    assert calls["prompt"] == 1
+    assert calls["save_config"] == 1
     assert event.isAccepted()
 
 
@@ -68,13 +86,9 @@ def test_close_event_cancel_ignores(gui, monkeypatch):
     from PySide6.QtGui import QCloseEvent
 
     monkeypatch.setattr(
-        "PySide6.QtWidgets.QMessageBox.question",
-        lambda *a, **k: QMessageBox.StandardButton.Cancel,
-    )
-    monkeypatch.setattr(
         gui,
-        "save_server_details",
-        lambda show_popup=True: (_ for _ in ()).throw(AssertionError("save")),
+        "_prompt_save_pending_configuration",
+        lambda context: QMessageBox.StandardButton.Cancel,
     )
     monkeypatch.setattr(
         gui,
@@ -93,20 +107,13 @@ def test_close_event_cancel_ignores(gui, monkeypatch):
 def test_close_event_discard_no_save(gui, monkeypatch):
     from PySide6.QtGui import QCloseEvent
 
-    calls = {"save_server": 0, "save_config": 0, "question": 0}
+    calls = {"save_config": 0, "prompt": 0}
 
-    def fake_question(*args, **kwargs):
-        calls["question"] += 1
+    def fake_prompt(context):
+        calls["prompt"] += 1
         return QMessageBox.StandardButton.Discard
 
-    monkeypatch.setattr("PySide6.QtWidgets.QMessageBox.question", fake_question)
-    monkeypatch.setattr(
-        gui,
-        "save_server_details",
-        lambda show_popup=True: calls.__setitem__(
-            "save_server", calls["save_server"] + 1
-        ),
-    )
+    monkeypatch.setattr(gui, "_prompt_save_pending_configuration", fake_prompt)
     monkeypatch.setattr(
         gui,
         "save_configuration",
@@ -120,8 +127,7 @@ def test_close_event_discard_no_save(gui, monkeypatch):
     gui.inputs["config"]["server"].setText("http://changed:2283")
     event = QCloseEvent()
     gui.closeEvent(event)
-    assert calls["question"] == 1
-    assert calls["save_server"] == 0
+    assert calls["prompt"] == 1
     assert calls["save_config"] == 0
     assert event.isAccepted()
 
@@ -135,9 +141,10 @@ def test_close_event_clean_skips_save_prompt(gui, monkeypatch):
         calls["question"] += 1
         return kwargs.get("defaultButton")
 
-    monkeypatch.setattr("PySide6.QtWidgets.QMessageBox.question", fake_question)
+    monkeypatch.setattr("gui.mixins.persistence.QMessageBox.question", fake_question)
     monkeypatch.setattr("gui.main_window.scan_locks", list)
     gui._mark_configuration_clean()
+    gui._mark_server_details_clean()
     event = QCloseEvent()
     gui.closeEvent(event)
     assert calls["question"] == 0

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -28,7 +28,7 @@ def test_running_process_boolean_state(gui):
 def test_close_event_save_prompt(gui, monkeypatch):
     from PySide6.QtGui import QCloseEvent
 
-    calls = {"save_config": 0, "prompt": 0}
+    calls = {"pending": 0, "prompt": 0}
 
     def fake_prompt(context):
         calls["prompt"] += 1
@@ -37,9 +37,9 @@ def test_close_event_save_prompt(gui, monkeypatch):
     monkeypatch.setattr(gui, "_prompt_save_pending_configuration", fake_prompt)
     monkeypatch.setattr(
         gui,
-        "save_configuration",
-        lambda show_popup=True: calls.__setitem__(
-            "save_config", calls["save_config"] + 1
+        "_save_pending_configuration",
+        lambda show_popup=False: calls.__setitem__(
+            "pending", calls["pending"] + 1
         ),
     )
     monkeypatch.setattr("gui.main_window.scan_locks", list)
@@ -49,14 +49,14 @@ def test_close_event_save_prompt(gui, monkeypatch):
     event = QCloseEvent()
     gui.closeEvent(event)
     assert calls["prompt"] == 1
-    assert calls["save_config"] == 1
+    assert calls["pending"] == 1
     assert event.isAccepted()
 
 
 def test_close_event_both_tracks_dirty_single_prompt(gui, monkeypatch):
     from PySide6.QtGui import QCloseEvent
 
-    calls = {"save_config": 0, "prompt": 0}
+    calls = {"pending": 0, "prompt": 0}
 
     def fake_prompt(context):
         calls["prompt"] += 1
@@ -65,9 +65,9 @@ def test_close_event_both_tracks_dirty_single_prompt(gui, monkeypatch):
     monkeypatch.setattr(gui, "_prompt_save_pending_configuration", fake_prompt)
     monkeypatch.setattr(
         gui,
-        "save_configuration",
-        lambda show_popup=True: calls.__setitem__(
-            "save_config", calls["save_config"] + 1
+        "_save_pending_configuration",
+        lambda show_popup=False: calls.__setitem__(
+            "pending", calls["pending"] + 1
         ),
     )
     monkeypatch.setattr("gui.main_window.scan_locks", list)
@@ -78,7 +78,7 @@ def test_close_event_both_tracks_dirty_single_prompt(gui, monkeypatch):
     event = QCloseEvent()
     gui.closeEvent(event)
     assert calls["prompt"] == 1
-    assert calls["save_config"] == 1
+    assert calls["pending"] == 1
     assert event.isAccepted()
 
 
@@ -92,8 +92,8 @@ def test_close_event_cancel_ignores(gui, monkeypatch):
     )
     monkeypatch.setattr(
         gui,
-        "save_configuration",
-        lambda show_popup=True: (_ for _ in ()).throw(AssertionError("save")),
+        "_save_pending_configuration",
+        lambda show_popup=False: (_ for _ in ()).throw(AssertionError("save")),
     )
     monkeypatch.setattr("gui.main_window.scan_locks", list)
     gui._mark_configuration_clean()
@@ -107,7 +107,7 @@ def test_close_event_cancel_ignores(gui, monkeypatch):
 def test_close_event_discard_no_save(gui, monkeypatch):
     from PySide6.QtGui import QCloseEvent
 
-    calls = {"save_config": 0, "prompt": 0}
+    calls = {"pending": 0, "prompt": 0}
 
     def fake_prompt(context):
         calls["prompt"] += 1
@@ -116,9 +116,9 @@ def test_close_event_discard_no_save(gui, monkeypatch):
     monkeypatch.setattr(gui, "_prompt_save_pending_configuration", fake_prompt)
     monkeypatch.setattr(
         gui,
-        "save_configuration",
-        lambda show_popup=True: calls.__setitem__(
-            "save_config", calls["save_config"] + 1
+        "_save_pending_configuration",
+        lambda show_popup=False: calls.__setitem__(
+            "pending", calls["pending"] + 1
         ),
     )
     monkeypatch.setattr("gui.main_window.scan_locks", list)
@@ -128,7 +128,7 @@ def test_close_event_discard_no_save(gui, monkeypatch):
     event = QCloseEvent()
     gui.closeEvent(event)
     assert calls["prompt"] == 1
-    assert calls["save_config"] == 0
+    assert calls["pending"] == 0
     assert event.isAccepted()
 
 


### PR DESCRIPTION
## Summary
- Migrate config profile schema to v3 and slim persistence to Configuration-page fields
- Save Server Details, unified close/profile save prompts, Linux XDG URL persistence
- Fix app-settings save wiping server credentials on Linux
- Document schema v3 persistence in user and developer guides

## Test plan
- [ ] `uv run pytest tests/test_persistence.py tests/test_config_manager.py tests/test_profiles_ui.py`

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Client Timeout setting to server configuration.
  * Added separate **Save Server Details** and **Check for Updates** actions.
  * Added application version and update status information.
  * Improved profile switching and closing behavior with consolidated save prompts.
  * Added support for schema v2-to-v3 configuration migration.

* **Bug Fixes**
  * Prevented server details and saved credentials from being unintentionally overwritten.
  * Improved reliability when migrating legacy configuration files.

* **Documentation**
  * Updated configuration, profiles, advanced flags, architecture, and developer guidance for schema v3 and session-only workflow settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->