### PR TITLE
fix: status eliding and static duration unit labels

### DIFF
--- a/gui/widgets/__init__.py
+++ b/gui/widgets/__init__.py
@@ -1,6 +1,6 @@
 from .advanced_flag_row import AdvancedFlagRow
 from .base_page import BasePage
-from .cards import Card, FormSection
+from .cards import Card, FormSection, spin_with_unit_label
 from .droppable import DroppableLineEdit, DroppablePlainTextEdit
 from .eliding_label import ElidingLabel
 from .navigation import NavGroup, NavItem
@@ -15,6 +15,7 @@ __all__ = [
     "DroppablePlainTextEdit",
     "ElidingLabel",
     "FormSection",
+    "spin_with_unit_label",
     "NavGroup",
     "NavItem",
     "StatusCard",

--- a/gui/widgets/advanced_flag_row.py
+++ b/gui/widgets/advanced_flag_row.py
@@ -8,6 +8,8 @@ from PySide6.QtWidgets import (
     QWidget,
 )
 
+from gui.widgets.cards import spin_with_unit_label
+
 
 class AdvancedFlagRow(QWidget):
     def __init__(self, def_, parent=None):
@@ -29,7 +31,10 @@ class AdvancedFlagRow(QWidget):
         layout.setContentsMargins(0, 0, 0, 0)
         layout.setSpacing(12)
         layout.addWidget(self.enable, 0)
-        layout.addWidget(self.value_widget, 1)
+        if self.def_.kind == "duration_minutes":
+            layout.addWidget(spin_with_unit_label(self.value_widget, "min"), 1)
+        else:
+            layout.addWidget(self.value_widget, 1)
 
     def _create_value_widget(self):
         kind = self.def_.kind
@@ -63,7 +68,6 @@ class AdvancedFlagRow(QWidget):
         if kind == "duration_minutes":
             w = QSpinBox()
             w.setRange(1, 1440)
-            w.setSuffix(" minutes")
             if isinstance(self.def_.default, int):
                 w.setValue(self.def_.default)
             else:

--- a/gui/widgets/cards.py
+++ b/gui/widgets/cards.py
@@ -31,6 +31,20 @@ class Card(QFrame):
         self.layout.addSpacing(16)
 
 
+def spin_with_unit_label(spin: QWidget, unit: str) -> QWidget:
+    """Place a spin box beside a static unit label (suffix text is not editable)."""
+    container = QWidget()
+    row = QHBoxLayout(container)
+    row.setContentsMargins(0, 0, 0, 0)
+    row.setSpacing(6)
+    row.addWidget(spin)
+    unit_lbl = QLabel(unit)
+    unit_lbl.setObjectName("FieldLabel")
+    row.addWidget(unit_lbl)
+    row.addStretch()
+    return container
+
+
 class FormSection(QFormLayout):
     def __init__(self, parent=None):
         super().__init__(parent)

--- a/gui/widgets/status_card.py
+++ b/gui/widgets/status_card.py
@@ -1,6 +1,8 @@
 from PySide6.QtCore import Qt
 from PySide6.QtWidgets import QFrame, QHBoxLayout, QLabel, QVBoxLayout
 
+from gui.widgets.eliding_label import ElidingLabel
+
 
 class StatusCard(QFrame):
     _DOT = {
@@ -23,7 +25,7 @@ class StatusCard(QFrame):
     def _row(self, lay, text):
         dot = QLabel()
         dot.setFixedSize(10, 10)
-        txt = QLabel(text)
+        txt = ElidingLabel(text, Qt.TextElideMode.ElideMiddle)
         txt.setObjectName("StatusText")
         r = QHBoxLayout()
         r.setSpacing(8)
@@ -40,7 +42,9 @@ class StatusCard(QFrame):
     def set_binary(self, state, text):
         self._paint(self.dot_b, state)
         self.txt_b.setText(text)
+        self.txt_b.setToolTip(text)
 
     def set_server(self, state, text):
         self._paint(self.dot_s, state)
         self.txt_s.setText(text)
+        self.txt_s.setToolTip(text)

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -3,6 +3,25 @@ from unittest.mock import patch
 from PySide6.QtWidgets import QMessageBox
 
 from core.command_builder import validate_state_light
+from gui.widgets.status_card import StatusCard
+
+
+def test_status_card_elides_and_sets_tooltip(qtbot):
+    card = StatusCard()
+    qtbot.addWidget(card)
+    card.resize(120, 80)
+    qtbot.waitExposed(card)
+    long_text = "Server: " + "x" * 200
+    card.set_server("ok", long_text)
+    assert card.txt_s.toolTip() == long_text
+    assert card.txt_s.text() == long_text
+    w = card.txt_s.contentsRect().width() or card.txt_s.width()
+    if w > 0:
+        elided = card.txt_s.fontMetrics().elidedText(
+            long_text, card.txt_s._elide, w
+        )
+        assert len(elided) < len(long_text)
+        assert "…" in elided
 
 
 def test_running_process_boolean_state(gui):

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -16,12 +16,12 @@ def test_status_card_elides_and_sets_tooltip(qtbot):
     assert card.txt_s.toolTip() == long_text
     assert card.txt_s.text() == long_text
     w = card.txt_s.contentsRect().width() or card.txt_s.width()
-    if w > 0:
-        elided = card.txt_s.fontMetrics().elidedText(
-            long_text, card.txt_s._elide, w
-        )
-        assert len(elided) < len(long_text)
-        assert "…" in elided
+    assert w > 0, "Widget must have a positive width for elision to be measurable"
+    elided = card.txt_s.fontMetrics().elidedText(
+        long_text, card.txt_s._elide, w
+    )
+    assert len(elided) < len(long_text)
+    assert "…" in elided
 
 
 def test_running_process_boolean_state(gui):

--- a/tests/test_tabs.py
+++ b/tests/test_tabs.py
@@ -158,7 +158,6 @@ def test_archive_ui_options_removed(gui):
 def test_config_tab_completeness(gui):
     assert "allow_untested_updates" in gui.inputs["config"]
     assert "preferred_terminal" in gui.inputs["config"]
-    assert gui.inputs["config"]["client_timeout_minutes"].suffix() == ""
     gui.inputs["config"]["allow_untested_updates"].setChecked(True)
     gui.inputs["config"]["preferred_terminal"].setCurrentText("konsole")
     gui.save_configuration()

--- a/tests/test_tabs.py
+++ b/tests/test_tabs.py
@@ -158,6 +158,7 @@ def test_archive_ui_options_removed(gui):
 def test_config_tab_completeness(gui):
     assert "allow_untested_updates" in gui.inputs["config"]
     assert "preferred_terminal" in gui.inputs["config"]
+    assert gui.inputs["config"]["client_timeout_minutes"].suffix() == ""
     gui.inputs["config"]["allow_untested_updates"].setChecked(True)
     gui.inputs["config"]["preferred_terminal"].setCurrentText("konsole")
     gui.save_configuration()

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -8,6 +8,18 @@ from gui.widgets import DroppablePlainTextEdit
 from gui.widgets.advanced_flag_row import AdvancedFlagRow
 
 
+def test_advanced_flag_row_duration_minutes_uses_static_unit_label(qtbot):
+    flag_def = next(
+        d
+        for defs in REGISTRY.flags.values()
+        for d in defs
+        if d.kind == "duration_minutes"
+    )
+    row = AdvancedFlagRow(flag_def)
+    qtbot.addWidget(row)
+    assert row.value_widget.suffix() == ""
+
+
 def test_advanced_flag_row_int_respects_flagdef_min_max(qtbot):
     """concurrent-tasks is 1-20 in flags.toml; UI must clamp, not 0-999999."""
     flag_def = next(


### PR DESCRIPTION
## Summary
- Elide long status card text with tooltips
- Replace QSpinBox suffix with `spin_with_unit_label` for advanced duration flags

## Test plan
- [ ] `uv run pytest tests/test_status.py tests/test_widgets.py tests/test_tabs.py`

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **UI Improvements**
  * Duration fields now display a consistent, non-editable “min” unit label.
  * Long status messages are shortened with an ellipsis to fit available space.
  * Full status text remains available via tooltips when truncated.

* **Tests**
  * Added coverage for duration unit labels and status text truncation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->