### PR TITLE
feat: application update check on Config tab and File menu

### DIFF
--- a/assets/theme.qss
+++ b/assets/theme.qss
@@ -169,6 +169,15 @@ QLabel#Hint {{
     color: {text_muted};
 }}
 
+QLabel#Hint a {{
+    color: {accent};
+    text-decoration: none;
+}}
+
+QLabel#Hint a:hover {{
+    text-decoration: underline;
+}}
+
 QLabel#WarningHint {{
     font-size: 12px;
     font-weight: 500;

--- a/core/app_update.py
+++ b/core/app_update.py
@@ -1,0 +1,56 @@
+"""GitHub release lookup for the Immich-Go GUI application itself."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+import requests
+from packaging.version import InvalidVersion, Version
+
+from core.binary_manager import clean_version
+
+_log = logging.getLogger(__name__)
+
+GITHUB_REPO = "shitan198u/immich-go-gui"
+LATEST_RELEASE_URL = f"https://api.github.com/repos/{GITHUB_REPO}/releases/latest"
+
+
+@dataclass
+class GuiReleaseInfo:
+    tag: str
+    version: str
+    html_url: str
+
+
+def get_latest_gui_release() -> GuiReleaseInfo | None:
+    """Fetch the latest GUI release from GitHub."""
+    try:
+        res = requests.get(LATEST_RELEASE_URL, timeout=15)
+        res.raise_for_status()
+        data = res.json()
+        tag = str(data.get("tag_name", "")).strip()
+        html_url = str(data.get("html_url", "")).strip()
+        if not tag:
+            return None
+        version = clean_version(tag)
+        if not version:
+            return None
+        if not html_url:
+            html_url = f"https://github.com/{GITHUB_REPO}/releases/latest"
+        return GuiReleaseInfo(tag=tag, version=version, html_url=html_url)
+    except Exception as exc:
+        _log.warning("Failed to fetch latest GUI release: %s", exc)
+        return None
+
+
+def is_update_available(installed_version: str, latest_version: str) -> bool:
+    """Return True when latest_version is newer than installed_version."""
+    installed = clean_version(installed_version)
+    latest = clean_version(latest_version)
+    if not installed or not latest:
+        return False
+    try:
+        return Version(latest) > Version(installed)
+    except InvalidVersion:
+        return latest != installed

--- a/core/app_update.py
+++ b/core/app_update.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import re
 from dataclasses import dataclass
 
 import requests
@@ -11,6 +12,37 @@ from packaging.version import InvalidVersion, Version
 from core.binary_manager import clean_version
 
 _log = logging.getLogger(__name__)
+
+_GUI_RELEASE_PREFIXES = ("immich-go-gui-v", "immich-go-gui-", "v")
+_SEMVER_PATTERN = re.compile(r"(\d+\.\d+\.\d+(?:[-+][\w.]+)?)")
+
+
+def clean_gui_release_version(tag: str) -> str:
+    """Extract semver from Release Please tags like ``immich-go-gui-v1.2.0``."""
+    tag = tag.strip()
+    if not tag:
+        return ""
+    lowered = tag.lower()
+    for prefix in _GUI_RELEASE_PREFIXES:
+        if lowered.startswith(prefix):
+            tag = tag[len(prefix) :]
+            break
+    match = _SEMVER_PATTERN.search(tag)
+    if match:
+        return match.group(1)
+    return clean_version(tag)
+
+
+def is_parseable_semver(version: str) -> bool:
+    """Return True when *version* is a valid PEP 440 semver after GUI tag cleanup."""
+    cleaned = clean_gui_release_version(version)
+    if not cleaned:
+        return False
+    try:
+        Version(cleaned)
+    except InvalidVersion:
+        return False
+    return True
 
 GITHUB_REPO = "shitan198u/immich-go-gui"
 LATEST_RELEASE_URL = f"https://api.github.com/repos/{GITHUB_REPO}/releases/latest"
@@ -33,7 +65,7 @@ def get_latest_gui_release() -> GuiReleaseInfo | None:
         html_url = str(data.get("html_url", "")).strip()
         if not tag:
             return None
-        version = clean_version(tag)
+        version = clean_gui_release_version(tag)
         if not version:
             return None
         if not html_url:
@@ -46,11 +78,13 @@ def get_latest_gui_release() -> GuiReleaseInfo | None:
 
 def is_update_available(installed_version: str, latest_version: str) -> bool:
     """Return True when latest_version is newer than installed_version."""
-    installed = clean_version(installed_version)
-    latest = clean_version(latest_version)
+    if not is_parseable_semver(installed_version):
+        return False
+    installed = clean_gui_release_version(installed_version)
+    latest = clean_gui_release_version(latest_version)
     if not installed or not latest:
         return False
     try:
         return Version(latest) > Version(installed)
     except InvalidVersion:
-        return latest != installed
+        return False

--- a/gui/mixins/app_update.py
+++ b/gui/mixins/app_update.py
@@ -55,13 +55,31 @@ class AppUpdateMixin:
 
     def check_for_application_updates(self) -> None:
         installed = _gui_version()
-        if not is_parseable_semver(installed):
-            self._set_app_update_status("Development build", "default")
-            return
+        is_dev = not is_parseable_semver(installed)
 
         release = get_latest_gui_release()
         if release is None:
             self._set_app_update_status("Could not check for updates.", "err")
+            QMessageBox.warning(
+                self,
+                "Update Check Failed",
+                "Could not reach GitHub to check for updates.\n"
+                "Check your network connection and try again.",
+            )
+            return
+
+        if is_dev:
+            self._set_app_update_status(
+                f"Development build — latest release is v{release.version}",
+                "default",
+            )
+            QMessageBox.information(
+                self,
+                "Development Build",
+                f"You are running a development build ({installed}).\n"
+                "Version comparison was skipped.\n"
+                f"The latest published release is v{release.version}.",
+            )
             return
 
         if is_update_available(installed, release.version):
@@ -85,6 +103,11 @@ class AppUpdateMixin:
 
         display = clean_display_version(installed)
         self._set_app_update_status(f"Up to date (v{display})", "ok")
+        QMessageBox.information(
+            self,
+            "Update Check",
+            f"You are on the latest release (v{display}).",
+        )
 
     def app_update_status_state(self) -> str:
         if not hasattr(self, "lbl_app_update_status"):

--- a/gui/mixins/app_update.py
+++ b/gui/mixins/app_update.py
@@ -4,7 +4,12 @@ from importlib.metadata import version as _pkg_version
 
 from PySide6.QtWidgets import QMessageBox
 
-from core.app_update import get_latest_gui_release, is_update_available
+from core.app_update import (
+    clean_gui_release_version,
+    get_latest_gui_release,
+    is_parseable_semver,
+    is_update_available,
+)
 
 
 def _gui_version() -> str:
@@ -21,9 +26,13 @@ class AppUpdateMixin:
     _APP_UPDATE_COLOR_ERR = "#EF4444"
 
     def _init_app_update_ui(self) -> None:
+        installed = _gui_version()
         if hasattr(self, "lbl_app_version"):
-            self.lbl_app_version.setText(f"Current Version: {_gui_version()}")
-        self._set_app_update_status(self._APP_UPDATE_STATUS_DEFAULT, "default")
+            self.lbl_app_version.setText(installed)
+        if not is_parseable_semver(installed):
+            self._set_app_update_status("Development build", "default")
+        else:
+            self._set_app_update_status(self._APP_UPDATE_STATUS_DEFAULT, "default")
 
     def _set_app_update_status(self, text: str, state: str) -> None:
         if not hasattr(self, "lbl_app_update_status"):
@@ -46,6 +55,10 @@ class AppUpdateMixin:
 
     def check_for_application_updates(self) -> None:
         installed = _gui_version()
+        if not is_parseable_semver(installed):
+            self._set_app_update_status("Development build", "default")
+            return
+
         release = get_latest_gui_release()
         if release is None:
             self._set_app_update_status("Could not check for updates.", "err")
@@ -87,6 +100,4 @@ class AppUpdateMixin:
 
 
 def clean_display_version(version: str) -> str:
-    from core.binary_manager import clean_version
-
-    return clean_version(version) or version
+    return clean_gui_release_version(version) or version

--- a/gui/mixins/app_update.py
+++ b/gui/mixins/app_update.py
@@ -1,0 +1,92 @@
+import webbrowser
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _pkg_version
+
+from PySide6.QtWidgets import QMessageBox
+
+from core.app_update import get_latest_gui_release, is_update_available
+
+
+def _gui_version() -> str:
+    try:
+        return _pkg_version("immich-go-gui")
+    except PackageNotFoundError:
+        return "dev"
+
+
+class AppUpdateMixin:
+    _APP_UPDATE_STATUS_DEFAULT = "Check for updates to see status."
+    _APP_UPDATE_COLOR_OK = "#22C55E"
+    _APP_UPDATE_COLOR_WARN = "#E5C07B"
+    _APP_UPDATE_COLOR_ERR = "#EF4444"
+
+    def _init_app_update_ui(self) -> None:
+        if hasattr(self, "lbl_app_version"):
+            self.lbl_app_version.setText(f"Current Version: {_gui_version()}")
+        self._set_app_update_status(self._APP_UPDATE_STATUS_DEFAULT, "default")
+
+    def _set_app_update_status(self, text: str, state: str) -> None:
+        if not hasattr(self, "lbl_app_update_status"):
+            return
+        self.lbl_app_update_status.setText(text)
+        if state == "ok":
+            self.lbl_app_update_status.setStyleSheet(
+                f"color: {self._APP_UPDATE_COLOR_OK};"
+            )
+        elif state == "warn":
+            self.lbl_app_update_status.setStyleSheet(
+                f"color: {self._APP_UPDATE_COLOR_WARN};"
+            )
+        elif state == "err":
+            self.lbl_app_update_status.setStyleSheet(
+                f"color: {self._APP_UPDATE_COLOR_ERR};"
+            )
+        else:
+            self.lbl_app_update_status.setStyleSheet("")
+
+    def check_for_application_updates(self) -> None:
+        installed = _gui_version()
+        release = get_latest_gui_release()
+        if release is None:
+            self._set_app_update_status("Could not check for updates.", "err")
+            return
+
+        if is_update_available(installed, release.version):
+            self._set_app_update_status(
+                f"Update available: v{release.version}", "warn"
+            )
+            msg = QMessageBox(self)
+            msg.setWindowTitle("Update Available")
+            msg.setText(
+                f"A newer version is available (v{release.version}).\n"
+                f"You are running v{installed}."
+            )
+            open_btn = msg.addButton(
+                "Open Download Page", QMessageBox.ButtonRole.AcceptRole
+            )
+            msg.addButton(QMessageBox.StandardButton.Close)
+            msg.exec()
+            if msg.clickedButton() == open_btn:
+                webbrowser.open(release.html_url)
+            return
+
+        display = clean_display_version(installed)
+        self._set_app_update_status(f"Up to date (v{display})", "ok")
+
+    def app_update_status_state(self) -> str:
+        if not hasattr(self, "lbl_app_update_status"):
+            return "default"
+        text = self.lbl_app_update_status.text()
+        if text.startswith("Up to date"):
+            return "ok"
+        if text.startswith("Update available"):
+            return "warn"
+        if text == "Could not check for updates.":
+            return "err"
+        return "default"
+
+
+def clean_display_version(version: str) -> str:
+    from core.binary_manager import clean_version
+
+    return clean_version(version) or version

--- a/gui/mixins/binary_ui.py
+++ b/gui/mixins/binary_ui.py
@@ -73,7 +73,7 @@ class BinaryUIMixin:
         if hasattr(self, "status_card"):
             self.status_card.set_binary(state, card_text)
         if hasattr(self, "lbl_binary_version"):
-            self.lbl_binary_version.setText(f"Current Version: {version_text}")
+            self.lbl_binary_version.setText(version_text)
         if hasattr(self, "lbl_binary_path"):
             self.lbl_binary_path.setText(getattr(self, "binary_path", ""))
 

--- a/gui/mixins/menu.py
+++ b/gui/mixins/menu.py
@@ -52,6 +52,12 @@ class MenuMixin:
 
         file_menu.addSeparator()
 
+        app_update_action = QAction("Check for Application Updates…", self)
+        app_update_action.triggered.connect(self.check_for_application_updates)
+        file_menu.addAction(app_update_action)
+
+        file_menu.addSeparator()
+
         exit_action = QAction("Exit", self)
         exit_action.triggered.connect(self.close)
         file_menu.addAction(exit_action)

--- a/gui/tabs/config_tab.py
+++ b/gui/tabs/config_tab.py
@@ -11,6 +11,7 @@ from PySide6.QtWidgets import (
 )
 
 from core import default_secrets_path, load_binary_metadata
+from gui.mixins.app_update import _gui_version
 from gui.widgets import BasePage, Card, ElidingLabel, FormSection
 from theme import THEME_DARK, THEME_LIGHT, THEME_SYSTEM
 
@@ -92,6 +93,40 @@ def build_config_tab(host) -> QWidget:
     card_sec.layout.addLayout(sec_form)
     page.addWidget(card_sec)
 
+    card_app = Card("Application")
+    app_form = FormSection()
+    host.lbl_app_version = QLabel(_gui_version())
+    host.lbl_app_version.setObjectName("FieldLabel")
+    host.lbl_app_version.setWordWrap(True)
+    app_form.add_row("Current Version", host.lbl_app_version)
+
+    host.lbl_app_update_status = QLabel("Check for updates to see status.")
+    host.lbl_app_update_status.setObjectName("AppUpdateStatus")
+    app_form.add_row("Status", host.lbl_app_update_status)
+
+    host.btn_check_app_updates = QPushButton("Check for Updates")
+    host.btn_check_app_updates.clicked.connect(host.check_for_application_updates)
+    app_form.add_row("", host.btn_check_app_updates)
+
+    releases_hint_container = QWidget()
+    releases_hint_layout = QVBoxLayout(releases_hint_container)
+    releases_hint_layout.setContentsMargins(0, 0, 0, 0)
+    releases_hint_layout.setSpacing(4)
+    releases_hint = QLabel("Downloads from GitHub Releases.")
+    releases_hint.setObjectName("Hint")
+    releases_link = QLabel(
+        "<a href='https://github.com/shitan198u/immich-go-gui/releases'>"
+        "github.com/shitan198u/immich-go-gui/releases</a>"
+    )
+    releases_link.setObjectName("Hint")
+    releases_link.setTextInteractionFlags(Qt.TextInteractionFlag.TextBrowserInteraction)
+    releases_link.setOpenExternalLinks(True)
+    releases_hint_layout.addWidget(releases_hint)
+    releases_hint_layout.addWidget(releases_link)
+    app_form.add_row("", releases_hint_container)
+    card_app.layout.addLayout(app_form)
+    page.addWidget(card_app)
+
     card2 = Card("Binary Management")
     row = QHBoxLayout()
     row.setSpacing(16)
@@ -168,6 +203,9 @@ def build_config_tab(host) -> QWidget:
     adv_card.setVisible(False)
     page.addWidget(adv_card)
     host.adv_frames.append(adv_card)
+
+    if hasattr(host, "_init_app_update_ui"):
+        host._init_app_update_ui()
 
     page.addStretch()
     return page

--- a/tests/test_app_update.py
+++ b/tests/test_app_update.py
@@ -2,6 +2,8 @@
 
 from unittest.mock import MagicMock, patch
 
+from PySide6.QtWidgets import QMessageBox
+
 from core.app_update import (
     GuiReleaseInfo,
     clean_gui_release_version,
@@ -78,6 +80,7 @@ def test_check_for_application_updates_up_to_date(monkeypatch):
             html_url="https://example.com/release",
         ),
     )
+    monkeypatch.setattr("gui.mixins.app_update.QMessageBox", MagicMock())
     host.check_for_application_updates()
     assert host.lbl_app_update_status.text().startswith("Up to date")
     assert host.app_update_status_state() == "ok"
@@ -116,9 +119,59 @@ def test_check_for_application_updates_dev_build(monkeypatch):
             html_url="https://example.com/release",
         ),
     )
+    monkeypatch.setattr("gui.mixins.app_update.QMessageBox", MagicMock())
     host.check_for_application_updates()
-    assert host.lbl_app_update_status.text() == "Development build"
+    assert host.lbl_app_update_status.text().startswith("Development build")
+    assert "1.2.0" in host.lbl_app_update_status.text()
     assert host.app_update_status_state() == "default"
+
+
+def test_check_for_application_updates_network_error(monkeypatch):
+    host = _UpdateHost()
+    monkeypatch.setattr(
+        "gui.mixins.app_update._gui_version",
+        lambda: "1.2.0",
+    )
+    monkeypatch.setattr(
+        "gui.mixins.app_update.get_latest_gui_release",
+        lambda: None,
+    )
+    monkeypatch.setattr("gui.mixins.app_update.QMessageBox", MagicMock())
+    host.check_for_application_updates()
+    assert host.lbl_app_update_status.text() == "Could not check for updates."
+    assert host.app_update_status_state() == "err"
+
+
+def test_check_for_application_updates_opens_download_page(monkeypatch):
+    host = _UpdateHost()
+    monkeypatch.setattr(
+        "gui.mixins.app_update._gui_version",
+        lambda: "1.1.0",
+    )
+    release_url = "https://example.com/release"
+    monkeypatch.setattr(
+        "gui.mixins.app_update.get_latest_gui_release",
+        lambda: GuiReleaseInfo(
+            tag="v1.2.0",
+            version="1.2.0",
+            html_url=release_url,
+        ),
+    )
+    open_mock = MagicMock()
+    monkeypatch.setattr("gui.mixins.app_update.webbrowser.open", open_mock)
+
+    msgbox_mock = MagicMock()
+    msgbox_mock.ButtonRole = QMessageBox.ButtonRole
+    msgbox_mock.StandardButton = QMessageBox.StandardButton
+    msg = MagicMock()
+    open_btn = MagicMock()
+    msg.addButton.return_value = open_btn
+    msg.clickedButton.return_value = open_btn
+    msgbox_mock.return_value = msg
+    monkeypatch.setattr("gui.mixins.app_update.QMessageBox", msgbox_mock)
+
+    host.check_for_application_updates()
+    open_mock.assert_called_once_with(release_url)
 
 
 def test_clean_display_version_strips_v_prefix():

--- a/tests/test_app_update.py
+++ b/tests/test_app_update.py
@@ -2,7 +2,13 @@
 
 from unittest.mock import MagicMock, patch
 
-from core.app_update import GuiReleaseInfo, get_latest_gui_release, is_update_available
+from core.app_update import (
+    GuiReleaseInfo,
+    clean_gui_release_version,
+    get_latest_gui_release,
+    is_parseable_semver,
+    is_update_available,
+)
 from gui.mixins.app_update import AppUpdateMixin, clean_display_version
 
 
@@ -12,21 +18,31 @@ def test_is_update_available_compares_versions():
     assert is_update_available("v1.2.0", "1.1.9") is False
 
 
+def test_clean_gui_release_version_strips_release_please_tag():
+    assert clean_gui_release_version("immich-go-gui-v1.2.0") == "1.2.0"
+    assert clean_gui_release_version("v1.2.1") == "1.2.1"
+
+
+def test_is_update_available_dev_build_never_reports_update():
+    assert is_parseable_semver("dev") is False
+    assert is_update_available("dev", "1.2.0") is False
+    assert is_update_available("dev", "immich-go-gui-v1.2.0") is False
+
+
 @patch("core.app_update.requests.get")
-def test_get_latest_gui_release_parses_tag(mock_get):
+def test_get_latest_gui_release_parses_release_please_tag(mock_get):
     mock_get.return_value = MagicMock(
         status_code=200,
         json=lambda: {
-            "tag_name": "v1.2.1",
-            "html_url": "https://github.com/shitan198u/immich-go-gui/releases/tag/v1.2.1",
+            "tag_name": "immich-go-gui-v1.2.0",
+            "html_url": "https://github.com/shitan198u/immich-go-gui/releases/tag/immich-go-gui-v1.2.0",
         },
     )
     mock_get.return_value.raise_for_status = MagicMock()
 
     release = get_latest_gui_release()
     assert release is not None
-    assert release.version == "1.2.1"
-    assert release.html_url.endswith("v1.2.1")
+    assert release.version == "1.2.0"
 
 
 class _StatusLabel:
@@ -86,5 +102,25 @@ def test_check_for_application_updates_available(monkeypatch):
     assert host.app_update_status_state() == "warn"
 
 
+def test_check_for_application_updates_dev_build(monkeypatch):
+    host = _UpdateHost()
+    monkeypatch.setattr(
+        "gui.mixins.app_update._gui_version",
+        lambda: "dev",
+    )
+    monkeypatch.setattr(
+        "gui.mixins.app_update.get_latest_gui_release",
+        lambda: GuiReleaseInfo(
+            tag="immich-go-gui-v1.2.0",
+            version="1.2.0",
+            html_url="https://example.com/release",
+        ),
+    )
+    host.check_for_application_updates()
+    assert host.lbl_app_update_status.text() == "Development build"
+    assert host.app_update_status_state() == "default"
+
+
 def test_clean_display_version_strips_v_prefix():
     assert clean_display_version("v1.2.3") == "1.2.3"
+    assert clean_display_version("immich-go-gui-v1.2.0") == "1.2.0"

--- a/tests/test_app_update.py
+++ b/tests/test_app_update.py
@@ -1,0 +1,90 @@
+"""Unit tests for GUI application update checks."""
+
+from unittest.mock import MagicMock, patch
+
+from core.app_update import GuiReleaseInfo, get_latest_gui_release, is_update_available
+from gui.mixins.app_update import AppUpdateMixin, clean_display_version
+
+
+def test_is_update_available_compares_versions():
+    assert is_update_available("1.0.0", "1.1.0") is True
+    assert is_update_available("1.1.0", "1.1.0") is False
+    assert is_update_available("v1.2.0", "1.1.9") is False
+
+
+@patch("core.app_update.requests.get")
+def test_get_latest_gui_release_parses_tag(mock_get):
+    mock_get.return_value = MagicMock(
+        status_code=200,
+        json=lambda: {
+            "tag_name": "v1.2.1",
+            "html_url": "https://github.com/shitan198u/immich-go-gui/releases/tag/v1.2.1",
+        },
+    )
+    mock_get.return_value.raise_for_status = MagicMock()
+
+    release = get_latest_gui_release()
+    assert release is not None
+    assert release.version == "1.2.1"
+    assert release.html_url.endswith("v1.2.1")
+
+
+class _StatusLabel:
+    def __init__(self):
+        self._text = ""
+
+    def setText(self, text):
+        self._text = text
+
+    def text(self):
+        return self._text
+
+    def setStyleSheet(self, _style):
+        pass
+
+
+class _UpdateHost(AppUpdateMixin):
+    def __init__(self):
+        self.lbl_app_update_status = _StatusLabel()
+
+
+def test_check_for_application_updates_up_to_date(monkeypatch):
+    host = _UpdateHost()
+    monkeypatch.setattr(
+        "gui.mixins.app_update._gui_version",
+        lambda: "1.2.0",
+    )
+    monkeypatch.setattr(
+        "gui.mixins.app_update.get_latest_gui_release",
+        lambda: GuiReleaseInfo(
+            tag="v1.2.0",
+            version="1.2.0",
+            html_url="https://example.com/release",
+        ),
+    )
+    host.check_for_application_updates()
+    assert host.lbl_app_update_status.text().startswith("Up to date")
+    assert host.app_update_status_state() == "ok"
+
+
+def test_check_for_application_updates_available(monkeypatch):
+    host = _UpdateHost()
+    monkeypatch.setattr(
+        "gui.mixins.app_update._gui_version",
+        lambda: "1.1.0",
+    )
+    monkeypatch.setattr(
+        "gui.mixins.app_update.get_latest_gui_release",
+        lambda: GuiReleaseInfo(
+            tag="v1.2.0",
+            version="1.2.0",
+            html_url="https://example.com/release",
+        ),
+    )
+    monkeypatch.setattr("gui.mixins.app_update.QMessageBox", MagicMock())
+    host.check_for_application_updates()
+    assert host.app_update_status_state() == "warn"
+
+
+def test_clean_display_version_strips_v_prefix():
+    assert clean_display_version("v1.2.3") == "1.2.3"


### PR DESCRIPTION
## Summary
- GitHub release lookup for the GUI itself with Config tab UI and File menu entry
- Tag parsing for Release Please tags; theme styles for update status

## Test plan
- [ ] `uv run pytest tests/test_app_update.py`

Made with [Cursor](https://cursor.com)