### PR TITLE
fix(test): isolate keyring operations and enforce XDG config dir in test suite

### DIFF
--- a/core/config_manager.py
+++ b/core/config_manager.py
@@ -145,15 +145,16 @@ def default_config_dir() -> Path:
     if env_override:
         return Path(env_override).parent
 
+    xdg = os.environ.get("XDG_CONFIG_HOME")
+    if xdg:
+        return Path(xdg) / "immich-go-gui"
+
     if sys.platform.startswith("win"):
         base = os.environ.get("APPDATA") or os.path.expanduser("~")
         return Path(base) / "immich-go-gui"
     elif sys.platform.startswith("darwin"):
         return Path.home() / "Library" / "Application Support" / "immich-go-gui"
     else:
-        xdg = os.environ.get("XDG_CONFIG_HOME")
-        if xdg:
-            return Path(xdg) / "immich-go-gui"
         return Path.home() / ".config" / "immich-go-gui"
 
 

--- a/docs/developer-guide/architecture.md
+++ b/docs/developer-guide/architecture.md
@@ -104,7 +104,7 @@ immich-go-gui/
 │   ├── validation.py
 │   ├── cli_help.py / cli_contract.py
 │   └── __init__.py        # Public re-exports
-├── tests/                 # Focused Pytest modules (20 modules, ~269 tests)
+├── tests/                 # Focused Pytest modules (20 modules, ~271 tests)
 ├── scripts/               # CLI help capture, review bundles, icon generator
 ├── docs/                  # User + developer + reference docs
 ├── packaging/             # Linux nfpm + Windows Inno Setup

--- a/docs/developer-guide/testing.md
+++ b/docs/developer-guide/testing.md
@@ -1,6 +1,6 @@
 # Testing
 
-The test suite lives in `tests/` (269 tests across 20 modules) using `pytest` and `pytest-qt`.
+The test suite lives in `tests/` (271 tests across 20 modules) using `pytest` and `pytest-qt`.
 
 ## Running Tests
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -121,6 +121,31 @@ def suppress_qt_dialogs(monkeypatch):
 
 
 @pytest.fixture(autouse=True)
+def _isolate_keyring(monkeypatch):
+    """Prevent tests from reading, writing, or deleting real OS keyring secrets."""
+    store = {}
+
+    def mock_get_password(service, username):
+        return store.get((service, username))
+
+    def mock_set_password(service, username, password):
+        store[(service, username)] = password
+
+    def mock_delete_password(service, username):
+        store.pop((service, username), None)
+
+    monkeypatch.setattr("keyring.get_password", mock_get_password)
+    monkeypatch.setattr("keyring.set_password", mock_set_password)
+    monkeypatch.setattr("keyring.delete_password", mock_delete_password)
+    monkeypatch.setattr("core.config_manager.keyring.get_password", mock_get_password)
+    monkeypatch.setattr("core.config_manager.keyring.set_password", mock_set_password)
+    monkeypatch.setattr(
+        "core.config_manager.keyring.delete_password", mock_delete_password
+    )
+    yield store
+
+
+@pytest.fixture(autouse=True)
 def _isolate_user_config(tmp_path, monkeypatch):
     """Keep tests off the developer's real ~/.config/immich-go-gui directory."""
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg-config"))

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -68,3 +68,22 @@ def test_save_config_schema_v3_without_form_state(tmp_path, monkeypatch):
     assert data["schema_version"] == 3
     assert data["server"]["client_timeout_minutes"] == 90
     assert "form_state" not in data
+
+
+def test_default_config_dir_respects_xdg_cross_platform(tmp_path, monkeypatch):
+    """Verify default_config_dir prefers XDG_CONFIG_HOME over platform defaults."""
+    from core.config_manager import default_config_dir
+
+    monkeypatch.delenv("IMMICH_GO_GUI_CONFIG", raising=False)
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "custom_xdg"))
+    assert default_config_dir() == tmp_path / "custom_xdg" / "immich-go-gui"
+
+
+def test_keyring_isolation_in_pytest():
+    """Verify SecretStore operations in test suite use in-memory mock keyring."""
+    from core.config_manager import SecretStore
+
+    assert SecretStore.set_secret("test_prof", "api_key", "mock_key_value") is True
+    assert SecretStore.get_secret("test_prof", "api_key") == "mock_key_value"
+    SecretStore.clear_secret("test_prof", "api_key")
+    assert SecretStore.get_secret("test_prof", "api_key") == ""


### PR DESCRIPTION
## Summary
Fixes a major issue where running pytest was overwriting or clearing real saved API keys in the host OS Keyring and modifying config files on non-Linux platforms.

### Changes Included
1. ****: Reordered `default_config_dir()` to respect `XDG_CONFIG_HOME` across all operating systems.
2. **`test(keyring)`**: Added autouse `_isolate_keyring` fixture in `conftest.py` to use per-test in-memory mock keyring storage and added unit tests in `test_config_manager.py`.
3. **`docs`**: Synced test count documentation to 271 tests.

### Verification
- `uv run pytest` (270 passed, 1 skipped)
- `uv run python app.py --self-test` (ok)
- `uv run pyright core/` (0 errors)
- `uv run pre-commit run --all-files` (all hooks passed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Configuration directory detection now honors `XDG_CONFIG_HOME` consistently across supported platforms.

* **Documentation**
  * Updated developer documentation to reflect the current test suite size.

* **Tests**
  * Improved test isolation by preventing tests from accessing the system keyring.
  * Added coverage for configuration directory selection and secure credential storage behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->