### PR TITLE
ci: replace pyright with ty and gate docs builds on releases

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -8,7 +8,7 @@ Authoritative context for AI agents working in this repository. When user-provid
 
 - **Step-by-step, source-first**: Read authoritative files (`core/flags.toml`, `core/command_builder.py`, tests) before editing. Do not guess flag names or CLI behavior.
 - **Frequent logical commits**: Small, reviewable commits with Conventional Commit prefixes (`fix:`, `feat:`, `chore:`, `test:`, `docs:`, `ci:`).
-- **Mandatory Pre-Commit Verification**: Run local checks (`uv run pre-commit run --all-files`, `uv run pyright core/`, `uv run python app.py --self-test`, `uv run python scripts/sync_version.py --check`) **before committing or opening PRs**. This guarantees `pr-fast-feedback.yml` passes on first attempt.
+- **Mandatory Pre-Commit Verification**: Run local checks (`uv run pre-commit run --all-files`, `uv run ty check core/`, `uv run python app.py --self-test`, `uv run python scripts/sync_version.py --check`) **before committing or opening PRs**. This guarantees `pr-fast-feedback.yml` passes on first attempt.
 - **Minimal scope**: Match existing patterns. Avoid drive-by refactors — especially splitting `app.py` unless explicitly requested.
 
 ---
@@ -22,6 +22,7 @@ Authoritative context for AI agents working in this repository. When user-provid
 | **pytest** | `uv run pytest` (Linux headless requires `libegl1 libgl1 libxkbcommon-x11-0`: `QT_QPA_PLATFORM=offscreen xvfb-run uv run pytest`) |
 | **Self-test** | `uv run python app.py --self-test` — loads registry, builds a plan, checks config dir |
 | **pre-commit** | `uv run pre-commit run --all-files` — mandatory check before committing or creating PRs |
+| **githooks** | Native git hooks in `.githooks/` configured via `git config core.hooksPath .githooks` |
 
 ### Git Branching
 
@@ -126,9 +127,9 @@ Nuitka directives live at the top of `app.py`. All release workflow invocations 
 
 | Workflow | Trigger | Purpose |
 |----------|---------|---------|
-| `ci.yml` | Push to `master` | Pyright (`core/`), pre-commit, multi-OS pytest + coverage, `--self-test` |
-| `pr-fast-feedback.yml` | PR | Multi-OS tests, Pyright, pre-commit, version sync check, pip-audit, CodeQL |
-| `docs.yml` | Push to `master` | Test count sync, MkDocs build, lychee link check, GitHub Pages deploy |
+| `ci.yml` | Push to `master` | `ty` type checker (`core/`), pre-commit, multi-OS pytest + coverage, `--self-test` |
+| `pr-fast-feedback.yml` | PR | Multi-OS tests, `ty` type checker, pre-commit, version sync check, pip-audit, CodeQL |
+| `docs.yml` | Tag `v*` / manual | Test count sync, MkDocs build, lychee link check, GitHub Pages deploy |
 | `release.yml` | Tag `v*` | **pytest gate** → Nuitka builds → SHA256SUMS → GitHub Release |
 | `release-please.yml` | Push to `master` | Version bump PR (updates pyproject.toml, manifest, docs via `extra-files`) |
 
@@ -161,7 +162,7 @@ uv run python scripts/sync_version.py --check        # verify pyproject.toml mat
 uv run python scripts/sync_test_count.py --sync       # sync pytest count to documentation
 uv run python scripts/capture_cli_help.py            # refresh CLI help fixtures
 uv run python scripts/generate_build_icons.py        # regenerate .ico and .icns from .png
-uv run pyright core/
+uv run ty check core/
 uv run pre-commit run --all-files                     # MANDATORY before commit/PR
 ```
 

--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -8,7 +8,7 @@ Authoritative context for AI agents working in this repository. When user-provid
 
 - **Step-by-step, source-first**: Read authoritative files (`core/flags.toml`, `core/command_builder.py`, tests) before editing. Do not guess flag names or CLI behavior.
 - **Frequent logical commits**: Small, reviewable commits with Conventional Commit prefixes (`fix:`, `feat:`, `chore:`, `test:`, `docs:`, `ci:`).
-- **Pre-Commit Verification**: The `.githooks/pre-commit` hook runs `pre-commit` (staged files only) automatically on every commit. Before **opening PRs**, run the full gate: `uv run pre-commit run --all-files`, `uv run ty check core/`, `uv run python app.py --self-test`, `uv run python scripts/sync_version.py --check`. This guarantees `pr-fast-feedback.yml` passes on first attempt.
+- **Pre-Commit Verification**: The `.githooks/pre-commit` hook runs `pre-commit` (staged files only) automatically on every commit. Before **opening PRs**, run the full local pre-PR gate: `uv run pre-commit run --all-files`, `uv run ty check core/`, `uv run python app.py --self-test`, `uv run python scripts/sync_version.py --check`. Note that `pr-fast-feedback.yml` additionally runs multi-OS pytest, test-count synchronization, and security checks (pip-audit, CodeQL).
 - **Minimal scope**: Match existing patterns. Avoid drive-by refactors — especially splitting `app.py` unless explicitly requested.
 
 ---
@@ -129,8 +129,8 @@ Nuitka directives live at the top of `app.py`. All release workflow invocations 
 |----------|---------|---------|
 | `ci.yml` | Push to `master` | `ty` type checker (`core/`), pre-commit, multi-OS pytest + coverage, `--self-test` |
 | `pr-fast-feedback.yml` | PR | Multi-OS tests, `ty` type checker, pre-commit, version sync check, pip-audit, CodeQL |
-| `docs.yml` | Tag `v*` / manual | Test count sync, MkDocs build, lychee link check, GitHub Pages deploy |
-| `release.yml` | Tag `v*` | **pytest gate** → Nuitka builds → SHA256SUMS → GitHub Release |
+| `docs.yml` | Tag `v[0-9]*` / manual | Test count sync, MkDocs build, lychee link check, GitHub Pages deploy |
+| `release.yml` | Tag `v[0-9]*` | **pytest gate** → Nuitka builds → SHA256SUMS → GitHub Release |
 | `release-please.yml` | Push to `master` | Version bump PR (updates pyproject.toml, manifest, docs via `extra-files`) |
 
 ### Packaging & Version Rules

--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -8,7 +8,7 @@ Authoritative context for AI agents working in this repository. When user-provid
 
 - **Step-by-step, source-first**: Read authoritative files (`core/flags.toml`, `core/command_builder.py`, tests) before editing. Do not guess flag names or CLI behavior.
 - **Frequent logical commits**: Small, reviewable commits with Conventional Commit prefixes (`fix:`, `feat:`, `chore:`, `test:`, `docs:`, `ci:`).
-- **Mandatory Pre-Commit Verification**: Run local checks (`uv run pre-commit run --all-files`, `uv run ty check core/`, `uv run python app.py --self-test`, `uv run python scripts/sync_version.py --check`) **before committing or opening PRs**. This guarantees `pr-fast-feedback.yml` passes on first attempt.
+- **Pre-Commit Verification**: The `.githooks/pre-commit` hook runs `pre-commit` (staged files only) automatically on every commit. Before **opening PRs**, run the full gate: `uv run pre-commit run --all-files`, `uv run ty check core/`, `uv run python app.py --self-test`, `uv run python scripts/sync_version.py --check`. This guarantees `pr-fast-feedback.yml` passes on first attempt.
 - **Minimal scope**: Match existing patterns. Avoid drive-by refactors — especially splitting `app.py` unless explicitly requested.
 
 ---
@@ -113,7 +113,7 @@ Nuitka directives live at the top of `app.py`. All release workflow invocations 
 
 ## 6. Testing
 
-- **Suite Metrics**: **269 tests across 20 modules**, coverage gate **80%** on `core` + `app` (Linux CI).
+- **Suite Metrics**: **271 tests across 20 modules**, coverage gate **75%** on `core` (Linux CI).
 - **Conventions**:
   - Windows path normalization: pass argv through `_norm_argv(...)` before comparing paths.
   - Golden fixtures: `tests/fixtures/command_states/*.json`

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Immich-Go GUI — Native Git Pre-Commit Hook
+set -e
+
+echo "🔍 Running pre-commit quality checks..."
+# Check staged files only; CI runs --all-files as the safety net.
+uv run pre-commit run

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,8 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libxkbcommon-x11-0 libxcb-cursor0 xvfb libegl1 libgl1 libxcb-xinerama0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-render-util0 libxcb-shape0
 
-      - name: Pyright (core)
-        run: uv run pyright core/
+      - name: ty Type Checker (core)
+        run: uv run ty check core/
 
       - name: Version Sync Check
         run: uv run python scripts/sync_version.py --check
@@ -41,7 +41,7 @@ jobs:
           fi
 
       - name: Pre-commit
-        run: SKIP=version-sync-check,test-count-sync-check uv run pre-commit run --all-files --show-diff-on-failure
+        run: SKIP=ty-check,version-sync-check,test-count-sync-check uv run pre-commit run --all-files --show-diff-on-failure
 
   test:
     needs: quality

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,9 +2,8 @@ name: Deploy Docs to GitHub Pages
 
 on:
   push:
-    branches:
-      - docs/comprehensive-documentation
-      - master
+    tags:
+      - 'v[0-9]*'
   workflow_dispatch:
 
 permissions:
@@ -70,13 +69,13 @@ jobs:
 
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v5
-        if: github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/master'
+        if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/')
         with:
           path: site/
 
   deploy:
     needs: build
-    if: github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/master'
+    if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     environment:
       name: github-pages

--- a/.github/workflows/pr-fast-feedback.yml
+++ b/.github/workflows/pr-fast-feedback.yml
@@ -130,11 +130,11 @@ jobs:
             libxcb-xinerama0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 \
             libxcb-render-util0 libxcb-shape0
 
-      - name: Pyright (core)
-        run: uv run pyright core/
+      - name: ty Type Checker (core)
+        run: uv run ty check core/
 
       - name: Pre-commit / Lint & Formatting
-        run: SKIP=version-sync-check,test-count-sync-check uv run pre-commit run --all-files --show-diff-on-failure
+        run: SKIP=ty-check,version-sync-check,test-count-sync-check uv run pre-commit run --all-files --show-diff-on-failure
 
       - name: Version Sync Check
         run: uv run python scripts/sync_version.py --check

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,6 +20,12 @@ repos:
 
   - repo: local
     hooks:
+      - id: ty-check
+        name: ty-check
+        entry: uv run ty check core/
+        language: system
+        pass_filenames: false
+        always_run: true
       - id: version-sync-check
         name: version-sync-check
         entry: uv run python scripts/sync_version.py --check

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,7 @@ repos:
         entry: uv run ty check core/
         language: system
         pass_filenames: false
-        always_run: true
+        files: ^core/
       - id: version-sync-check
         name: version-sync-check
         entry: uv run python scripts/sync_version.py --check

--- a/core/binary_manager.py
+++ b/core/binary_manager.py
@@ -158,7 +158,7 @@ def load_binary_metadata(metadata_path: str = METADATA_PATH) -> dict:
                         get_version_support(version).value,
                     )
                     record.setdefault("sha256", "")
-                record.setdefault("release_url", "")
+                    record.setdefault("release_url", "")
         meta["schema_version"] = 2
 
     return meta

--- a/core/binary_manager.py
+++ b/core/binary_manager.py
@@ -144,15 +144,20 @@ def load_binary_metadata(metadata_path: str = METADATA_PATH) -> dict:
             pass
 
     # Schema version migration
-    if meta.get("schema_version", 1) < 2:
-        for version, record in meta.get("versions", {}).items():
-            if isinstance(record, dict):
-                record.setdefault("gui_tested", version in TESTED_IMMICH_GO_VERSIONS)
-                record.setdefault(
-                    "support_status",
-                    get_version_support(version).value,
-                )
-                record.setdefault("sha256", "")
+    schema_ver = meta.get("schema_version", 1)
+    if isinstance(schema_ver, int) and schema_ver < 2:
+        versions_dict = meta.get("versions", {})
+        if isinstance(versions_dict, dict):
+            for version, record in versions_dict.items():
+                if isinstance(record, dict):
+                    record.setdefault(
+                        "gui_tested", version in TESTED_IMMICH_GO_VERSIONS
+                    )
+                    record.setdefault(
+                        "support_status",
+                        get_version_support(version).value,
+                    )
+                    record.setdefault("sha256", "")
                 record.setdefault("release_url", "")
         meta["schema_version"] = 2
 

--- a/core/cli_contract.py
+++ b/core/cli_contract.py
@@ -48,7 +48,8 @@ def check_fixtures(version: str = TESTED_IMMICH_GO_VERSION) -> CompatibilityRepo
     """Evaluates GUI flag allowlists against captured help fixtures for a version."""
     report = CompatibilityReport(version=version)
     matrix_entry = COMPATIBILITY_MATRIX.get(version, {})
-    report.notes = matrix_entry.get("notes", "")
+    notes_val = matrix_entry.get("notes", "")
+    report.notes = str(notes_val) if notes_val else ""
 
     fixtures_dir = Path(__file__).resolve().parent / "fixtures" / "cli_help" / version
     if not fixtures_dir.exists():
@@ -113,7 +114,8 @@ def check_binary_help(
     """Runs --help on target subcommands of live binary and compares against GUI allowlists."""
     report = CompatibilityReport(version=version)
     matrix_entry = COMPATIBILITY_MATRIX.get(version, {})
-    report.notes = matrix_entry.get("notes", "")
+    notes_val = matrix_entry.get("notes", "")
+    report.notes = str(notes_val) if notes_val else ""
 
     for tab_key, args in _TAB_SUBCOMMANDS.items():
         gui_allowed = TAB_ALLOWED_FLAGS.get(tab_key, set())

--- a/core/config_manager.py
+++ b/core/config_manager.py
@@ -11,10 +11,7 @@ from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
 
-try:
-    import tomllib
-except ModuleNotFoundError:
-    import tomli as tomllib
+import tomllib
 
 import keyring
 import tomli_w

--- a/core/flag_registry.py
+++ b/core/flag_registry.py
@@ -12,10 +12,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Literal
 
-try:
-    import tomllib
-except ModuleNotFoundError:
-    import tomli as tomllib
+import tomllib
 
 _FLAGS_TOML = Path(__file__).resolve().parent / "flags.toml"
 

--- a/core/profile_manager.py
+++ b/core/profile_manager.py
@@ -11,10 +11,7 @@ from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
 
-try:
-    import tomllib
-except ModuleNotFoundError:
-    import tomli as tomllib
+import tomllib
 
 import tomli_w
 

--- a/docs/developer-guide/ci-cd-and-releases.md
+++ b/docs/developer-guide/ci-cd-and-releases.md
@@ -13,12 +13,13 @@ Pull requests go directly to `master`. Use **squash merge** when appropriate to 
 
 | Workflow | File | Trigger | Purpose |
 |----------|------|---------|---------|
-| CI Checks | `.github/workflows/ci.yml` | Push to `master` | Multi-OS pytest |
+| CI Checks | `.github/workflows/ci.yml` | Push to `master` | `ty` type check, pre-commit, multi-OS pytest |
 | PR Fast Feedback | `.github/workflows/pr-fast-feedback.yml` | PR to `master` | Tests, version sync, security audit, PR comments |
 | CodeQL | `.github/workflows/codeql.yml` | Push/PR/schedule | Python security scanning |
 | Release Please | `.github/workflows/release-please.yml` | Push to `master` | Automated version bump PR |
 | Release Build | `.github/workflows/release.yml` | Tag `v[0-9]*` or manual | Build and publish release artifacts |
 | Manual Prerelease | `.github/workflows/manual-prerelease.yml` | Manual dispatch | Pre-release builds |
+| Docs | `.github/workflows/docs.yml` | Tag `v[0-9]*` or manual | MkDocs build, link check, GitHub Pages deploy |
 
 ## Release Please
 
@@ -86,6 +87,7 @@ a full Nuitka smoke-build pass on all three platforms.
 - **Package manager:** Always use `uv` (`uv sync`, `uv run pytest`, `uv run app.py`)
 - **GitHub CLI:** Use standard user auth for `gh` commands locally; do not pass `GITHUB_TOKEN`/`GH_TOKEN` overrides
 - **Lint/format:** Ruff via pre-commit
+- **Type checking:** `ty` via pre-commit (`core/`)
 
 ## Dependabot
 

--- a/docs/developer-guide/testing.md
+++ b/docs/developer-guide/testing.md
@@ -120,7 +120,7 @@ Local lint/format checks via pre-commit:
 uv run pre-commit run --all-files
 ```
 
-Configured in `.pre-commit-config.yaml`: trailing whitespace, YAML check, Ruff lint/format.
+Configured in `.pre-commit-config.yaml`: trailing whitespace, YAML check, Ruff lint/format, and `ty` type checking of `core/`.
 
 ## CI Matrix
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,3 +49,10 @@ markers = [
 # composition (host attributes on `self`) that yields false positives under
 # strict static analysis — see `.agents/AGENTS.md`.
 include = ["core"]
+
+[tool.ty.rules]
+unresolved-import = "warn"
+unresolved-attribute = "warn"
+
+[tool.ty.terminal]
+error-on-warning = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,13 +26,13 @@ dev = [
     "pre-commit>=4.6.0",
     "pyfakefs>=5.5.0",
     "pymdown-extensions>=10.14",
-    "pyright>=1.1.390",
     "pytest>=9.1.1",
     "pytest-cov>=6.0.0",
     "pytest-qt>=4.5.0",
     "pytest-timeout>=2.3.1",
     "pytest-xdist>=3.8.0",
     "ruff>=0.9.0",
+    "ty>=0.0.65",
 ]
 
 [tool.pytest.ini_options]
@@ -44,10 +44,8 @@ markers = [
     "integration: end-to-end tests that execute real subprocesses",
 ]
 
-[tool.pyright]
-venvPath = "."
-venv = ".venv"
-pythonVersion = "3.13"
-include = ["core", "gui"]
-reportMissingImports = "warning"
-reportAttributeAccessIssue = "warning"
+[tool.ty.src]
+# Type-check only `core/`. The Qt GUI mixins in `gui/` rely on runtime
+# composition (host attributes on `self`) that yields false positives under
+# strict static analysis — see `.agents/AGENTS.md`.
+include = ["core"]

--- a/tests/test_binary_ui.py
+++ b/tests/test_binary_ui.py
@@ -326,3 +326,44 @@ def test_check_binary_help_all_11_tabs(tmp_path, monkeypatch):
     monkeypatch.setattr("core.cli_contract.subprocess.run", fake_run)
     check_binary_help(tmp_path / "immich-go")
     assert len(calls) == 11
+
+
+def test_load_binary_metadata_migration_non_dict_record(tmp_path):
+    """Regression test: load_binary_metadata handles non-dict version entries during migration."""
+    from core.binary_manager import load_binary_metadata
+    import json
+
+    metadata_path = tmp_path / "metadata.json"
+
+    # Create a metadata file with schema_version 1 (or missing)
+    # where 'versions' contains both a dict record and a non-dict (string) record
+    corrupt_meta = {
+        "schema_version": 1,
+        "selected_version": "0.32.0",
+        "manual_path": "",
+        "versions": {
+            "0.32.0": {
+                "path": "/some/path/immich-go",
+                "downloaded_at": "2024-01-01T00:00:00Z",
+            },
+            "0.31.0": "some-string-value",  # Non-dict entry
+        },
+    }
+
+    with open(metadata_path, "w", encoding="utf-8") as f:
+        json.dump(corrupt_meta, f)
+
+    # This should not raise AttributeError
+    result = load_binary_metadata(str(metadata_path))
+
+    # Verify migration completed
+    assert result["schema_version"] == 2
+
+    # Verify dict record got defaults applied
+    assert "gui_tested" in result["versions"]["0.32.0"]
+    assert "support_status" in result["versions"]["0.32.0"]
+    assert "sha256" in result["versions"]["0.32.0"]
+    assert "release_url" in result["versions"]["0.32.0"]
+
+    # Verify non-dict entry was left as-is (not modified, no crash)
+    assert result["versions"]["0.31.0"] == "some-string-value"

--- a/uv.lock
+++ b/uv.lock
@@ -323,13 +323,13 @@ dev = [
     { name = "pre-commit" },
     { name = "pyfakefs" },
     { name = "pymdown-extensions" },
-    { name = "pyright" },
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "pytest-qt" },
     { name = "pytest-timeout" },
     { name = "pytest-xdist" },
     { name = "ruff" },
+    { name = "ty" },
 ]
 
 [package.metadata]
@@ -355,13 +355,13 @@ dev = [
     { name = "pre-commit", specifier = ">=4.6.0" },
     { name = "pyfakefs", specifier = ">=5.5.0" },
     { name = "pymdown-extensions", specifier = ">=10.14" },
-    { name = "pyright", specifier = ">=1.1.390" },
     { name = "pytest", specifier = ">=9.1.1" },
     { name = "pytest-cov", specifier = ">=6.0.0" },
     { name = "pytest-qt", specifier = ">=4.5.0" },
     { name = "pytest-timeout", specifier = ">=2.3.1" },
     { name = "pytest-xdist", specifier = ">=3.8.0" },
     { name = "ruff", specifier = ">=0.9.0" },
+    { name = "ty", specifier = ">=0.0.65" },
 ]
 
 [[package]]
@@ -742,19 +742,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pyright"
-version = "1.1.411"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "nodeenv" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/7e/ab/265f7dc69d28113ebba19092e57b075f41543b2ed048429c5f56e2b88eac/pyright-1.1.411.tar.gz", hash = "sha256:d885a0551f2e763b089a02702174e7f4ba77548cddabc972ab86d1f7f1b0f998", size = 4112861, upload-time = "2026-06-25T02:14:06.37Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/0a/49/385be530a6a5b78d1cbcd5c2e38debc8959a2fc6bdb716f4e581002979fc/pyright-1.1.411-py3-none-any.whl", hash = "sha256:dc7c72a8e2700c55baa127554040e067041ea53ccfd50bf96308cc4291c7d5d9", size = 6181526, upload-time = "2026-06-25T02:14:04.691Z" },
-]
-
-[[package]]
 name = "pyside6"
 version = "6.8.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1033,6 +1020,31 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/19/75/241269d1da26b624c0d5e110e8149093c759b7a286138f4efd61a60e75fe/tomli_w-1.2.0.tar.gz", hash = "sha256:2dd14fac5a47c27be9cd4c976af5a12d87fb1f0b4512f81d69cce3b35ae25021", size = 7184, upload-time = "2025-01-15T12:07:24.262Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/18/c86eb8e0202e32dd3df50d43d7ff9854f8e0603945ff398974c1d91ac1ef/tomli_w-1.2.0-py3-none-any.whl", hash = "sha256:188306098d013b691fcadc011abd66727d3c414c571bb01b1a174ba8c983cf90", size = 6675, upload-time = "2025-01-15T12:07:22.074Z" },
+]
+
+[[package]]
+name = "ty"
+version = "0.0.65"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cf561927e8e9ab5c1892a833b664aa9cd6f051a75f6280c66d8047246bda/ty-0.0.65.tar.gz", hash = "sha256:b7134bffcc00b715fa8291e84d845782ced810a998dc1f7f11d71c85c4046325", size = 6460098, upload-time = "2026-07-29T18:31:03.27Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/4e/71e2d325d2b53a1afad81624ad076b2ede413213fc4a18cb05b78c568571/ty-0.0.65-py3-none-linux_armv6l.whl", hash = "sha256:dc556c9f05408bef4c4ef02b2cc382e4e5f797b4b20d64410289848f0d76705f", size = 12298466, upload-time = "2026-07-29T18:30:12.744Z" },
+    { url = "https://files.pythonhosted.org/packages/57/77/fec8f29647c55794efa430a7f365e44f5ce7ffb6459d9445a87fac569bec/ty-0.0.65-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:29d2e0d34cc0a28a17ef0cf81135c5ebabc3562131f9079138ba5e7bae0f56bd", size = 11942421, upload-time = "2026-07-29T18:30:16.076Z" },
+    { url = "https://files.pythonhosted.org/packages/13/09/7f3766aef9dc627e2698cf4e3e59cf53389dcae3812040d33c1aa931230f/ty-0.0.65-py3-none-macosx_11_0_arm64.whl", hash = "sha256:685f49a9312bbf69d5b65bbb66384fed1f927403ea030c217b9289092d7e46c4", size = 11451922, upload-time = "2026-07-29T18:30:19.155Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/7b/1a77cd50e0befb50f55b8bf9bd3ed3eddf184bf28c61b56727039e0774fc/ty-0.0.65-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6f564b5ebe78e2f3a8e7b8eacb1292eb88b7c0f3c8630671cfca31abc0709cd9", size = 11994999, upload-time = "2026-07-29T18:30:22.315Z" },
+    { url = "https://files.pythonhosted.org/packages/63/7b/feda16f3a4a0a99be27431e0c9598eeeec0db1eb2fec9a15976698209418/ty-0.0.65-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c983e156fe9e113fb56389e13d327b6b8549fe866de9b269684723a88e9b732d", size = 12090662, upload-time = "2026-07-29T18:30:24.93Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/3e/3f69bf9c9307dbdc0771719f65ce5b556e7bdeeaccbdd599d4f57866d801/ty-0.0.65-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e3663b7396e8b1a9954e20e732de7ccb0192bf4118473069b4945920d6923921", size = 12822094, upload-time = "2026-07-29T18:30:28.012Z" },
+    { url = "https://files.pythonhosted.org/packages/90/38/8fa791b3bb503ee2b46ad81690cd1bdd54519582df6d805cee57fe143e85/ty-0.0.65-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:306ed01f29d6e108e98feb233dbbf5878a027603b71bd3743b343977933a9f16", size = 13357833, upload-time = "2026-07-29T18:30:31.122Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/73/4dda396a201e1dd0ed3594a9b48e559cb41c4bc048c6cd4c4d1b39eb4313/ty-0.0.65-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:28bcfc8898c94f079a9100e684bcf312b6a64ad3a7d4ebb35a4591546030a2cd", size = 12977303, upload-time = "2026-07-29T18:30:33.944Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/26/c250c2c569adc53a8591716641388397bcb2a442e4a30b952ae81b50c0e0/ty-0.0.65-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5a75bd0c245c38802a8f488378e74f92feb7dd33db7d63fbdd6fdf82791ba730", size = 12579338, upload-time = "2026-07-29T18:30:37.199Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/94/4a5647d44753ca218fc930d7e4d9bf468d0ed4a0ad4b3d57588bc1bbacf7/ty-0.0.65-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:9e5e1bdea9662d2b5312b4e99f319f4e6e2ea427511b5fbc546141b79ec53f76", size = 12957731, upload-time = "2026-07-29T18:30:39.937Z" },
+    { url = "https://files.pythonhosted.org/packages/36/b6/1e22fa11a1e0dfb20b1c7f3cbfd8170273aada2a82f9ecd3055275370c44/ty-0.0.65-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:03a88493d4842889f65280ae241e06b399d57eb3c63571054cad21a4c33b3b69", size = 11938625, upload-time = "2026-07-29T18:30:42.603Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/0a/fe5f22ef62b193201bc5566762e22049762cd485bfafb5095a7050760054/ty-0.0.65-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:600b8bf6f4940cf7ffb2f43d3716faaf38dcb97cd8617c55771451bc0276408f", size = 12105592, upload-time = "2026-07-29T18:30:45.419Z" },
+    { url = "https://files.pythonhosted.org/packages/76/fd/922b3a6e9d697452cdbb4b7e3f636868add5ec652154518a736e4364f3b7/ty-0.0.65-py3-none-musllinux_1_2_i686.whl", hash = "sha256:0c28007bc79d648c1ddaf1e65885d07baec48eb87240da442f608e4107c1b7d8", size = 12387335, upload-time = "2026-07-29T18:30:48.405Z" },
+    { url = "https://files.pythonhosted.org/packages/77/22/a1a08ebc84c083db2fb55e3b5cd186db0c067692f4921146f601360231e2/ty-0.0.65-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:c852da96091ad22361e6586b7c7ba98e1334dcd4d8ffb67e47f4fb673de33f77", size = 12682710, upload-time = "2026-07-29T18:30:51.364Z" },
+    { url = "https://files.pythonhosted.org/packages/81/14/eaaa410a25bbdea19722109b5422380a0e211b3afcf3071d15953ddbd5db/ty-0.0.65-py3-none-win32.whl", hash = "sha256:cf529d538f1403b14b0511e6ec3cdb95d3d974adabf24cc76cedc533368c3edc", size = 11692341, upload-time = "2026-07-29T18:30:54.35Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/0f/6d48f206dce9d7e53fe3b5ea0f0ab5800dd9d2365b2b48f736783436c43f/ty-0.0.65-py3-none-win_amd64.whl", hash = "sha256:234a321e33c7cbbfbd67bfa0b01b685dd9c21f1841781a21e5ca1fa0b25f1d5d", size = 12729355, upload-time = "2026-07-29T18:30:57.275Z" },
+    { url = "https://files.pythonhosted.org/packages/96/aa/7446f7725e303cf78e058c893af1f0552b9451895454908706f4c6c3494b/ty-0.0.65-py3-none-win_arm64.whl", hash = "sha256:b9424be1ec56d93ff18609fb1c0a0a2283fe1282cd6d1c7604f97d73b94d61f2", size = 12051375, upload-time = "2026-07-29T18:31:00.579Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
Transitions the type-checking toolchain from Pyright to Astral's **`ty`**, completing the unified `uv` + `ruff` + `ty` Rust-powered stack.

### Key Changes
- **`pyproject.toml`**: Configured `[tool.ty.src] = ["core"]`, scoping `ty check` to `core/`.
- **CI Workflows (`ci.yml`, `pr-fast-feedback.yml`)**: Replaced Pyright step with `uv run ty check core/`.
- **Docs Workflow (`docs.yml`)**: Gated documentation deployment on release tags (`v*`) and manual dispatch.
- **Native Git Hooks (`.githooks/pre-commit`)**: Configured staged file checks on local commits and added `ty-check` to pre-commit config.
- **Core Codebase**: Added explicit type guards and standard library `tomllib` imports for Python 3.13.
- **Agent Guide (`AGENTS.md`)**: Updated pre-commit rules, test counts, and commands for the `ty` workflow.

### Verification
- `uv run ty check core/` -> **All checks passed!**
- `uv run python app.py --self-test` -> **ok**
- `uv run pre-commit run --all-files` -> **Passed** (all 9 hooks)
- `uv run pytest` -> **270 passed, 1 skipped**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of saved configuration versions, reducing the risk of migration errors with unexpected version values.
  - Standardized diagnostic notes so validation results are reported consistently, including when details are unavailable.

- **Documentation**
  - Updated contributor guidance for type checking, testing, CI validation, and release workflows.
  - Clarified documentation publishing triggers for versioned releases.

- **Chores**
  - Strengthened commit and CI quality checks with automated validation and streamlined tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->