### PR TITLE
test: add guardrail tests, optimize suite, and fix PR-triggered CI

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -10,6 +10,7 @@ Authoritative context for AI agents working in this repository. When user-provid
 - **Frequent logical commits**: Small, reviewable commits with Conventional Commit prefixes (`fix:`, `feat:`, `chore:`, `test:`, `docs:`, `ci:`).
 - **Pre-Commit Verification**: The `.githooks/pre-commit` hook runs `pre-commit` (staged files only) automatically on every commit. Before **opening PRs**, run the full local pre-PR gate: `uv run pre-commit run --all-files`, `uv run ty check core/`, `uv run python app.py --self-test`, `uv run python scripts/sync_version.py --check`. Note that `pr-fast-feedback.yml` additionally runs multi-OS pytest, test-count synchronization, and security checks (pip-audit, CodeQL).
 - **Mandatory Pre-Commit Verification**: Run local checks (`uv run pre-commit run --all-files`, `uv run ty check core/`, `uv run python app.py --self-test`, `uv run python scripts/sync_version.py --check`) **before committing or opening PRs**. This guarantees `pr-fast-feedback.yml` passes on first attempt.
+- **Pre-Commit Verification**: The `.githooks/pre-commit` hook runs `pre-commit` (staged files only) automatically on every commit. Before **opening PRs**, run the full gate: `uv run pre-commit run --all-files`, `uv run ty check core/`, `uv run python app.py --self-test`, `uv run python scripts/sync_version.py --check`. This guarantees `pr-fast-feedback.yml` passes on first attempt.
 - **Minimal scope**: Match existing patterns. Avoid drive-by refactors — especially splitting `app.py` unless explicitly requested.
 
 ---
@@ -115,6 +116,7 @@ Nuitka directives live at the top of `app.py`. All release workflow invocations 
 
 ## 6. Testing
 
+- **Suite Metrics**: **271 tests across 20 modules**, coverage gate **75%** on `core` (Linux CI).
 - **Suite Metrics**: **271 tests across 20 modules**, coverage gate **75%** on `core` (Linux CI).
 - **Conventions**:
   - Windows path normalization: pass argv through `_norm_argv(...)` before comparing paths.

--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -9,6 +9,7 @@ Authoritative context for AI agents working in this repository. When user-provid
 - **Step-by-step, source-first**: Read authoritative files (`core/flags.toml`, `core/command_builder.py`, tests) before editing. Do not guess flag names or CLI behavior.
 - **Frequent logical commits**: Small, reviewable commits with Conventional Commit prefixes (`fix:`, `feat:`, `chore:`, `test:`, `docs:`, `ci:`).
 - **Pre-Commit Verification**: The `.githooks/pre-commit` hook runs `pre-commit` (staged files only) automatically on every commit. Before **opening PRs**, run the full local pre-PR gate: `uv run pre-commit run --all-files`, `uv run ty check core/`, `uv run python app.py --self-test`, `uv run python scripts/sync_version.py --check`. Note that `pr-fast-feedback.yml` additionally runs multi-OS pytest, test-count synchronization, and security checks (pip-audit, CodeQL).
+- **Mandatory Pre-Commit Verification**: Run local checks (`uv run pre-commit run --all-files`, `uv run ty check core/`, `uv run python app.py --self-test`, `uv run python scripts/sync_version.py --check`) **before committing or opening PRs**. This guarantees `pr-fast-feedback.yml` passes on first attempt.
 - **Minimal scope**: Match existing patterns. Avoid drive-by refactors — especially splitting `app.py` unless explicitly requested.
 
 ---
@@ -22,6 +23,7 @@ Authoritative context for AI agents working in this repository. When user-provid
 | **pytest** | `uv run pytest` (Linux headless requires `libegl1 libgl1 libxkbcommon-x11-0`: `QT_QPA_PLATFORM=offscreen xvfb-run uv run pytest`) |
 | **Self-test** | `uv run python app.py --self-test` — loads registry, builds a plan, checks config dir |
 | **pre-commit** | `uv run pre-commit run --all-files` — mandatory check before committing or creating PRs |
+| **githooks** | Native git hooks in `.githooks/` configured via `git config core.hooksPath .githooks` |
 | **githooks** | Native git hooks in `.githooks/` configured via `git config core.hooksPath .githooks` |
 
 ### Git Branching
@@ -129,8 +131,8 @@ Nuitka directives live at the top of `app.py`. All release workflow invocations 
 |----------|---------|---------|
 | `ci.yml` | Push to `master` | `ty` type checker (`core/`), pre-commit, multi-OS pytest + coverage, `--self-test` |
 | `pr-fast-feedback.yml` | PR | Multi-OS tests, `ty` type checker, pre-commit, version sync check, pip-audit, CodeQL |
-| `docs.yml` | Tag `v[0-9]*` / manual | Test count sync, MkDocs build, lychee link check, GitHub Pages deploy |
-| `release.yml` | Tag `v[0-9]*` | **pytest gate** → Nuitka builds → SHA256SUMS → GitHub Release |
+| `docs.yml` | Tag `v*` / manual | Test count sync, MkDocs build, lychee link check, GitHub Pages deploy |
+| `release.yml` | Tag `v*` | **pytest gate** → Nuitka builds → SHA256SUMS → GitHub Release |
 | `release-please.yml` | Push to `master` | Version bump PR (updates pyproject.toml, manifest, docs via `extra-files`) |
 
 ### Packaging & Version Rules
@@ -162,6 +164,7 @@ uv run python scripts/sync_version.py --check        # verify pyproject.toml mat
 uv run python scripts/sync_test_count.py --sync       # sync pytest count to documentation
 uv run python scripts/capture_cli_help.py            # refresh CLI help fixtures
 uv run python scripts/generate_build_icons.py        # regenerate .ico and .icns from .png
+uv run ty check core/
 uv run ty check core/
 uv run pre-commit run --all-files                     # MANDATORY before commit/PR
 ```

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -2,6 +2,15 @@
 # Immich-Go GUI — Native Git Pre-Commit Hook
 set -e
 
+# Ensure user bin directories are in PATH for GUI applications (e.g. VSCode)
+export PATH="$HOME/.local/bin:$HOME/.cargo/bin:$HOME/.astral/uv/bin:/usr/local/bin:$PATH"
+
+if ! command -v uv >/dev/null 2>&1; then
+    echo "❌ Error: 'uv' command not found."
+    echo "Please ensure uv is installed and in your PATH."
+    exit 1
+fi
+
 echo "🔍 Running pre-commit quality checks..."
 # Check staged files only; CI runs --all-files as the safety net.
-uv run pre-commit run
+exec uv run pre-commit run "$@"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,8 +3,10 @@ name: "CodeQL"
 on:
   push:
     branches: [ "master" ]
+  # NOTE: No `branches:` filter on pull_request — CI must run on PRs targeting
+  # ANY base branch. Filtering to `branches: [master]` only caused PRs opened
+  # against staging to silently get zero CI checks.
   pull_request:
-    branches: [ "master" ]
   schedule:
     - cron: '30 1 * * 0' # Run every Sunday at 1:30 AM
 

--- a/.github/workflows/pr-fast-feedback.yml
+++ b/.github/workflows/pr-fast-feedback.yml
@@ -5,9 +5,10 @@ name: PR Fast Feedback
 # Nuitka build verification, and posts automated PR feedback.
 
 on:
+  # NOTE: No `branches:` filter here — CI must run on PRs targeting ANY base
+  # branch (master, staging, etc.). Filtering to `branches: [master]` only
+  # caused PRs opened against staging to silently get zero CI checks.
   pull_request:
-    branches:
-      - master
   workflow_dispatch:
 
 permissions:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
         args: ['--maxkb=2000'] # Allows up to 2MB (for your PNG files)
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.9.9
+    rev: v0.16.0
     hooks:
       # Run the linter
       - id: ruff

--- a/docs/developer-guide/architecture.md
+++ b/docs/developer-guide/architecture.md
@@ -104,7 +104,7 @@ immich-go-gui/
 │   ├── validation.py
 │   ├── cli_help.py / cli_contract.py
 │   └── __init__.py        # Public re-exports
-├── tests/                 # Focused Pytest modules (20 modules, ~271 tests)
+├── tests/                 # Focused Pytest modules (20 modules, ~423 tests)
 ├── scripts/               # CLI help capture, review bundles, icon generator
 ├── docs/                  # User + developer + reference docs
 ├── packaging/             # Linux nfpm + Windows Inno Setup

--- a/docs/developer-guide/testing.md
+++ b/docs/developer-guide/testing.md
@@ -1,6 +1,6 @@
 # Testing
 
-The test suite lives in `tests/` (271 tests across 20 modules) using `pytest` and `pytest-qt`.
+The test suite lives in `tests/` (423 tests across 27 modules) using `pytest` and `pytest-qt`.
 
 ## Running Tests
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,8 +40,17 @@ minversion = "7.0"
 testpaths = ["tests"]
 pythonpath = ["."]
 timeout = 120
+# Default run excludes integration + live_cli (require real subprocess/binary);
+# unit + gui + theme + security + slow stay opt-in-only on-demand.
+addopts = "-ra --strict-markers --durations=20 -m 'not integration and not live_cli'"
 markers = [
     "integration: end-to-end tests that execute real subprocesses",
+    "live_cli: tests that require a real immich-go binary",
+    "gui: Qt widget tests",
+    "theme: tests that require real theme/icon rendering",
+    "security: security-invariant tests",
+    "unit: pure-core tests that do not require the Qt application",
+    "slow: tests that are slow to run",
 ]
 
 [tool.ty.src]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -83,11 +83,22 @@ def gui(qapp, _session_config_root):
         with patch.object(ImmichGoGUI, "load_configuration"):
             g = ImmichGoGUI()
         g.binary_path = "./immich-go"
-        # Never fire silent connection tests during the suite — they hit the
-        # network with a 4s timeout and dominate wall time when Qt processes events.
-        if hasattr(g, "_conn_test_debounce"):
-            g._conn_test_debounce.stop()
-            g._conn_test_debounce.timeout.disconnect()
+        # Stop ALL background timers so tests never pay for deferred work that
+        # fires when Qt processes events. `_conn_test_debounce` is the obvious
+        # one; `_status_debounce` (150ms) and `_cleanup_timer` (6h) also do
+        # widget work and can fire mid-test.
+        for _timer_name in (
+            "_conn_test_debounce",
+            "_status_debounce",
+            "_cleanup_timer",
+            "binary_debounce",
+        ):
+            _timer = getattr(g, _timer_name, None)
+            if _timer is not None:
+                try:
+                    _timer.stop()
+                except Exception:
+                    pass
         g._auto_test_connection = lambda: None
         g._mark_configuration_clean()
         if hasattr(g, "_mark_server_details_clean"):
@@ -98,10 +109,15 @@ def gui(qapp, _session_config_root):
 
 
 @pytest.fixture(autouse=True)
-def _reset_client_timeout(gui):
-    spin = gui.inputs.get("config", {}).get("client_timeout_minutes")
-    if spin is not None:
-        spin.setValue(60)
+def _reset_client_timeout(request):
+    # Pure-core tests (unit marker, no `gui` fixture) must not pay the full
+    # ImmichGoGUI construction cost. Only run the reset when the test actually
+    # requests the shared `gui` fixture (or the gui marker is applied).
+    if "gui" in request.fixturenames:
+        gui = request.getfixturevalue("gui")
+        spin = gui.inputs.get("config", {}).get("client_timeout_minutes")
+        if spin is not None:
+            spin.setValue(60)
     yield
 
 
@@ -167,7 +183,11 @@ def _clear_profiles_cache():
 
 
 @pytest.fixture(autouse=True)
-def _reset_shared_config(gui):
+def _reset_shared_config(request):
+    if "gui" not in request.fixturenames:
+        yield
+        return
+    gui = request.getfixturevalue("gui")
     cfg = gui.inputs["config"]
     cfg["skip-ssl"].setChecked(False)
     if cfg.get("server"):
@@ -185,6 +205,25 @@ def _reset_shared_config(gui):
         picasa["folder-album"].setCurrentIndex(0)
     if "into-album" in picasa:
         picasa["into-album"].clear()
+
+
+@pytest.fixture(autouse=True)
+def _block_network(monkeypatch):
+    """Deny real network access so a stray requests call fails fast instead of
+    hanging the suite on a multi-second timeout (also enforces hermeticity).
+    Tests that legitimately exercise network code re-patch requests explicitly
+    inside the test body, which overrides this deny via monkeypatch last-wins.
+    """
+    import requests
+
+    def _deny(*args, **kwargs):
+        raise RuntimeError(
+            "Tests must not make real network calls. Patch requests explicitly."
+        )
+
+    for _name in ("get", "post", "put", "delete", "head", "patch"):
+        monkeypatch.setattr(requests, _name, _deny)
+    monkeypatch.setattr(requests.Session, "request", _deny)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_advanced_flag_emission.py
+++ b/tests/test_advanced_flag_emission.py
@@ -1,0 +1,149 @@
+"""Advanced flag emission guardrails.
+
+Verifies that the schema-driven advanced-flag mechanism behaves correctly for
+every flag in every tab:
+
+* disabled advanced rows are never emitted to argv,
+* enabled advanced rows (with a non-default value) are emitted to argv,
+* secret advanced flags are routed to env vars, never argv,
+* hidden flags are never exposed as advanced definitions.
+"""
+
+from typing import Any
+
+import pytest
+
+from core.command_builder import build_plan_from_state
+from core.flag_registry import REGISTRY, FlagDef
+
+IMMICH_SOURCE_TABS = ("upload-immich", "archive-immich")
+
+
+def _trigger_value(def_: FlagDef) -> Any:
+    """Return a value guaranteed to produce CLI args for *def_*'s kind."""
+    if def_.kind == "bool":
+        return True
+    if def_.kind == "enum":
+        return def_.options[0] if def_.options else "x"
+    if def_.kind == "int":
+        return 1
+    if def_.kind == "duration_minutes":
+        return 5
+    if def_.kind == "date_range":
+        return "2023-01-01,2023-12-31"
+    if def_.kind == "extensions":
+        return ".jpg"
+    if def_.kind in ("csv_repeat", "lines_repeat"):
+        return "alpha"
+    if def_.kind in ("text", "path", "paths"):
+        return "/tmp/x"
+    return "x"
+
+
+def _config_state():
+    # admin_api_key present so the pause-jobs safety override is skipped.
+    return {
+        "server": "http://localhost:2283",
+        "api_key": "k",
+        "admin_api_key": "a",
+        "skip-ssl": False,
+        "client_timeout_minutes": 60,
+    }
+
+
+def _tab_state(tab_key, tmp_path):
+    state: dict = {}
+    if tab_key != "stack" and tab_key != "archive-immich":
+        state["path"] = str(tmp_path / "src")
+    if tab_key in (
+        "archive-folder",
+        "archive-gp",
+        "archive-icloud",
+        "archive-picasa",
+        "archive-immich",
+    ):
+        state["write-to"] = str(tmp_path / "out")
+    if tab_key in IMMICH_SOURCE_TABS:
+        state["from-server"] = "http://src:2283"
+        state["from-api-key"] = "fk"
+    return state
+
+
+def _build(tab_key, advanced_state, tmp_path):
+    return build_plan_from_state(
+        tab_key=tab_key,
+        config_state=_config_state(),
+        tab_state=_tab_state(tab_key, tmp_path),
+        binary_path="./immich-go",
+        base_env={},
+        advanced_state=advanced_state,
+    )
+
+
+def _has_flag(argv, flag_name):
+    prefix = f"--{flag_name}"
+    return any(a == prefix or a.startswith(f"{prefix}=") for a in argv)
+
+
+def _emittable_defs(tab_key):
+    """Advanced defs we can meaningfully test for argv emission."""
+    return [
+        d
+        for d in REGISTRY.advanced_defs(tab_key)
+        if d.flag and not d.secret_env and "dry-run" not in d.key
+    ]
+
+
+@pytest.mark.parametrize("tab_key", sorted(REGISTRY.tabs))
+def test_disabled_advanced_flags_not_emitted(tab_key, tmp_path):
+    defs = _emittable_defs(tab_key)
+    if not defs:
+        pytest.skip(f"No emittable advanced flags for {tab_key}")
+    advanced_state = {
+        d.key: {"enabled": False, "value": _trigger_value(d)} for d in defs
+    }
+    plan = _build(tab_key, advanced_state, tmp_path)
+    leaked = [d.flag for d in defs if _has_flag(plan.argv, d.flag)]
+    assert not leaked, (
+        f"{tab_key}: disabled advanced flags leaked into argv: {leaked}\n"
+        f"argv={plan.argv}"
+    )
+
+
+@pytest.mark.parametrize("tab_key", sorted(REGISTRY.tabs))
+def test_enabled_advanced_flags_are_emitted(tab_key, tmp_path):
+    defs = _emittable_defs(tab_key)
+    if not defs:
+        pytest.skip(f"No emittable advanced flags for {tab_key}")
+    missing = []
+    for d in defs:
+        advanced_state = {d.key: {"enabled": True, "value": _trigger_value(d)}}
+        plan = _build(tab_key, advanced_state, tmp_path)
+        if not _has_flag(plan.argv, d.flag):
+            missing.append(d.flag)
+    assert not missing, f"{tab_key}: enabled advanced flags not emitted: {missing}"
+
+
+@pytest.mark.parametrize("tab_key", sorted(REGISTRY.tabs))
+def test_secret_advanced_flags_routed_to_env(tab_key, tmp_path):
+    secret_defs = [d for d in REGISTRY.advanced_defs(tab_key) if d.secret_env]
+    if not secret_defs:
+        pytest.skip(f"No secret advanced flags for {tab_key}")
+    token = "secret-value-via-env-only"
+    advanced_state = {d.key: {"enabled": True, "value": token} for d in secret_defs}
+    plan = _build(tab_key, advanced_state, tmp_path)
+    joined = " ".join(plan.argv)
+    for d in secret_defs:
+        assert token not in joined, (
+            f"{tab_key}: secret flag {d.key} leaked to argv: {plan.argv}"
+        )
+        assert plan.env.get(d.secret_env) == token, (
+            f"{tab_key}: secret flag {d.key} not in env[{d.secret_env}]: {plan.env}"
+        )
+
+
+@pytest.mark.parametrize("tab_key", sorted(REGISTRY.tabs))
+def test_hidden_flags_not_exposed_as_advanced_defs(tab_key):
+    """REGISTRY.advanced_defs must never include hidden flags."""
+    for d in REGISTRY.advanced_defs(tab_key):
+        assert not d.hidden, f"{tab_key}: hidden flag {d.key} exposed in advanced_defs"

--- a/tests/test_app_update.py
+++ b/tests/test_app_update.py
@@ -75,7 +75,7 @@ class _UpdateHost(AppUpdateMixin):
         self.lbl_app_update_status = _StatusLabel()
 
 
-def test_check_for_application_updates_up_to_date(monkeypatch):
+def test_check_for_application_updates_up_to_date(qapp, monkeypatch):
     host = _UpdateHost()
     monkeypatch.setattr(
         "gui.mixins.app_update._gui_version",
@@ -96,7 +96,7 @@ def test_check_for_application_updates_up_to_date(monkeypatch):
     assert host.app_update_status_state() == "ok"
 
 
-def test_check_for_application_updates_available(monkeypatch):
+def test_check_for_application_updates_available(qapp, monkeypatch):
     host = _UpdateHost()
     monkeypatch.setattr(
         "gui.mixins.app_update._gui_version",
@@ -116,7 +116,7 @@ def test_check_for_application_updates_available(monkeypatch):
     assert host.app_update_status_state() == "warn"
 
 
-def test_check_for_application_updates_dev_build(monkeypatch):
+def test_check_for_application_updates_dev_build(qapp, monkeypatch):
     host = _UpdateHost()
     monkeypatch.setattr(
         "gui.mixins.app_update._gui_version",
@@ -138,7 +138,7 @@ def test_check_for_application_updates_dev_build(monkeypatch):
     assert host.app_update_status_state() == "default"
 
 
-def test_check_for_application_updates_network_error(monkeypatch):
+def test_check_for_application_updates_network_error(qapp, monkeypatch):
     host = _UpdateHost()
     monkeypatch.setattr(
         "gui.mixins.app_update._gui_version",
@@ -155,7 +155,7 @@ def test_check_for_application_updates_network_error(monkeypatch):
     assert host.app_update_status_state() == "err"
 
 
-def test_check_for_application_updates_opens_download_page(monkeypatch):
+def test_check_for_application_updates_opens_download_page(qapp, monkeypatch):
     host = _UpdateHost()
     monkeypatch.setattr(
         "gui.mixins.app_update._gui_version",

--- a/tests/test_architecture.py
+++ b/tests/test_architecture.py
@@ -1,0 +1,79 @@
+"""Architecture guardrails: enforce structural invariants that protect the
+long-term design of the codebase.
+
+These tests are intentionally Qt-free and pure-Python so they run fast and
+catch AI-agent-introduced architecture violations (e.g. importing PySide6
+into ``core/``, which must remain Qt-free and testable without a GUI).
+"""
+
+import ast
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CORE_ROOT = REPO_ROOT / "core"
+GUI_ROOT = REPO_ROOT / "gui"
+
+# Qt bindings that must never appear in core/.
+FORBIDDEN_TOP_LEVELS = {"PySide6", "PyQt6", "PyQt5"}
+
+
+def _iter_py(root: Path):
+    """Yield every .py file under *root*, skipping bytecode caches."""
+    for path in root.rglob("*.py"):
+        if "__pycache__" in path.parts:
+            continue
+        yield path
+
+
+def _imported_top_levels(path: Path):
+    """Yield (path, top_level_module) for every import in *path*."""
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                yield path, alias.name.split(".")[0]
+        elif isinstance(node, ast.ImportFrom):
+            mod = (node.module or "").split(".")[0]
+            if mod:
+                yield path, mod
+
+
+def test_core_is_qt_free():
+    """core/ must never import PySide6 or any Qt binding."""
+    offenders = [
+        (p.name, top)
+        for p in _iter_py(CORE_ROOT)
+        for _, top in _imported_top_levels(p)
+        if top in FORBIDDEN_TOP_LEVELS
+    ]
+    assert not offenders, f"Qt imports found in core/: {offenders}"
+
+
+def test_core_does_not_import_gui():
+    """core/ must not depend on the gui/ package (no circular dependency)."""
+    offenders = [
+        (p.name, top)
+        for p in _iter_py(CORE_ROOT)
+        for _, top in _imported_top_levels(p)
+        if top == "gui"
+    ]
+    assert not offenders, f"core/ imports gui/: {offenders}"
+
+
+def test_core_models_is_qt_free_by_import():
+    """Importing core.models must succeed without PySide6 installed concept.
+
+    A smoke test that the pure-data module imports cleanly and exposes the
+    expected dataclasses used across the codebase.
+    """
+    from core.models import (
+        AppConfig,
+        CommandPlan,
+        ValidationResult,
+    )
+
+    plan = CommandPlan()
+    assert plan.argv == []
+    assert plan.env == {}
+    assert ValidationResult().is_valid is True
+    assert AppConfig().schema_version == 3

--- a/tests/test_cli_contract.py
+++ b/tests/test_cli_contract.py
@@ -1,0 +1,77 @@
+"""CLI compatibility contract guardrails.
+
+Ensures the GUI flag allowlists (derived from flags.toml) stay in sync with
+the captured immich-go ``--help`` fixtures, and that the ignored-upstream-flag
+set is well-formed. These catch CLI parity drift when flags.toml or the CLI
+fixtures change.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from core import cli_help
+from core.binary_manager import TESTED_IMMICH_GO_VERSION
+from core.cli_contract import IGNORED_UPSTREAM_FLAGS, check_fixtures
+from core.cli_help import help_name_for_tab, load_help_fixture
+from core.flag_registry import REGISTRY
+
+
+def test_ignored_upstream_flags_is_frozenset():
+    assert isinstance(IGNORED_UPSTREAM_FLAGS, frozenset)
+
+
+def test_ignored_upstream_flags_contains_secret_flags():
+    """Secret flags that immich-go accepts but the GUI routes via env."""
+    for f in ("api-key", "admin-api-key", "from-api-key", "from-admin-api-key"):
+        assert f in IGNORED_UPSTREAM_FLAGS, (
+            f"{f!r} should be ignored as an upstream flag"
+        )
+
+
+def test_check_fixtures_fully_compatible():
+    """GUI allowlists must not reference flags absent from CLI fixtures."""
+    report = check_fixtures()
+    assert report.supported, (
+        f"CLI fixtures report unsupported for {report.version}: {report.notes}"
+    )
+    missing = {
+        tab: flags for tab, flags in report.missing_flags_by_tab.items() if flags
+    }
+    assert not missing, f"GUI references flags missing from CLI fixtures: {missing}"
+
+
+@pytest.mark.parametrize("tab_key", sorted(REGISTRY.tabs))
+def test_help_fixture_exists_for_every_tab(tab_key):
+    """A captured --help fixture must exist for each tab's subcommand."""
+    name = help_name_for_tab(tab_key)
+    flags = load_help_fixture(TESTED_IMMICH_GO_VERSION, name)
+    assert flags, (
+        f"No help fixture for {tab_key} ({name}.txt) at "
+        f"version {TESTED_IMMICH_GO_VERSION}"
+    )
+
+
+def test_cli_help_manifest_exists():
+    """The fixture manifest must be present for the tested version."""
+    manifest = (
+        Path(cli_help.__file__).resolve().parent
+        / "fixtures"
+        / "cli_help"
+        / TESTED_IMMICH_GO_VERSION
+        / "manifest.json"
+    )
+    assert manifest.exists(), (
+        f"manifest.json missing for version {TESTED_IMMICH_GO_VERSION}"
+    )
+
+
+def test_every_gui_allowed_flag_is_in_registry():
+    """TAB_ALLOWED_FLAGS must be derived from the registry (SSOT)."""
+    from core.cli_schema import TAB_ALLOWED_FLAGS
+
+    for tab_key, allowed in TAB_ALLOWED_FLAGS.items():
+        registry_allowed = REGISTRY.allowed_flags(tab_key)
+        assert allowed == registry_allowed, (
+            f"{tab_key}: TAB_ALLOWED_FLAGS drifted from REGISTRY"
+        )

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -4,7 +4,7 @@ from core.binary_manager import TESTED_IMMICH_GO_VERSION
 from gui import ImmichGoGUI
 
 
-def test_keyring_probe_warning(monkeypatch):
+def test_keyring_probe_warning(qapp, monkeypatch):
     """Probe failure during init should surface a warning when keyring is selected."""
 
     warn = MagicMock()

--- a/tests/test_flag_registry.py
+++ b/tests/test_flag_registry.py
@@ -86,6 +86,7 @@ def test_picasa_simple_keys_are_not_advanced_only():
     assert "recursive" in REGISTRY.advanced_keys("upload-picasa")
 
 
+@pytest.mark.live_cli
 def test_bool_defaults_match_live_cli():
     """Bool flag defaults in flags.toml must match live immich-go --help output."""
     import subprocess

--- a/tests/test_flags_toml_schema.py
+++ b/tests/test_flags_toml_schema.py
@@ -1,0 +1,111 @@
+"""Schema guardrails for core/flags.toml — the single source of truth.
+
+Validates that the parsed ``REGISTRY`` satisfies structural invariants so a
+malformed ``flags.toml`` is caught immediately rather than silently producing
+wrong command plans. These tests protect the SSOT from AI-agent edits that
+introduce invalid kinds, duplicate keys, or broken secret routing.
+"""
+
+import pytest
+
+from core.flag_registry import REGISTRY
+
+VALID_KINDS = {
+    "bool",
+    "text",
+    "enum",
+    "int",
+    "duration_minutes",
+    "extensions",
+    "csv_repeat",
+    "lines_repeat",
+    "date_range",
+    "path",
+    "paths",
+}
+VALID_SECTIONS = {"upload", "archive", "stack"}
+
+
+def test_registry_has_eleven_tabs():
+    """The GUI defines exactly 11 workflow tabs."""
+    assert len(REGISTRY.tabs) == 11
+
+
+def test_all_tabs_have_known_sections():
+    for key, tab in REGISTRY.tabs.items():
+        assert tab.section in VALID_SECTIONS, (
+            f"Tab {key} has unknown section {tab.section!r}"
+        )
+
+
+def test_all_tabs_have_nonempty_command():
+    for key, tab in REGISTRY.tabs.items():
+        assert tab.command, f"Tab {key} has empty command"
+
+
+def test_server_required_and_serverless_are_mutually_exclusive():
+    for key, tab in REGISTRY.tabs.items():
+        assert not (tab.server_required and tab.serverless), (
+            f"Tab {key} is both server_required and serverless"
+        )
+
+
+def test_all_flag_kinds_are_valid():
+    for tab_key, defs in REGISTRY.flags.items():
+        for d in defs:
+            assert d.kind in VALID_KINDS, (
+                f"Tab {tab_key} flag {d.key} has invalid kind {d.kind!r}"
+            )
+
+
+def test_enum_flags_have_options():
+    for tab_key, defs in REGISTRY.flags.items():
+        for d in defs:
+            if d.kind == "enum":
+                assert d.options, f"Tab {tab_key} enum flag {d.key} has no options"
+
+
+def test_no_duplicate_flag_keys_within_tab():
+    for tab_key, defs in REGISTRY.flags.items():
+        keys = [d.key for d in defs]
+        dupes = {k for k in keys if keys.count(k) > 1}
+        assert not dupes, f"Tab {tab_key} has duplicate flag keys: {dupes}"
+
+
+def test_no_duplicate_cli_flag_names_within_tab():
+    for tab_key, defs in REGISTRY.flags.items():
+        names = [d.flag for d in defs if d.flag]
+        dupes = {n for n in names if names.count(n) > 1}
+        assert not dupes, f"Tab {tab_key} has duplicate CLI flag names: {dupes}"
+
+
+def test_secret_env_flags_use_immich_go_prefix():
+    for tab_key, defs in REGISTRY.flags.items():
+        for d in defs:
+            if d.secret_env:
+                assert d.secret_env.startswith("IMMICH_GO_"), (
+                    f"Tab {tab_key} flag {d.key} secret_env "
+                    f"{d.secret_env!r} lacks IMMICH_GO_ prefix"
+                )
+
+
+def test_flags_reference_existing_tabs():
+    tab_keys = set(REGISTRY.tabs)
+    for flag_tab in REGISTRY.flags:
+        assert flag_tab in tab_keys, f"flags reference unknown tab {flag_tab!r}"
+
+
+def test_secrets_reference_existing_tabs():
+    tab_keys = set(REGISTRY.tabs)
+    for sec_tab in REGISTRY.secrets:
+        assert sec_tab in tab_keys, f"secrets reference unknown tab {sec_tab!r}"
+
+
+@pytest.mark.parametrize("tab_key", sorted(REGISTRY.server_required_tabs))
+def test_server_required_tab_has_secret_mapping(tab_key):
+    """Every server-required tab must route at least one secret via env."""
+    mapping = REGISTRY.env_key_map.get(tab_key, {})
+    assert mapping, f"Server-required tab {tab_key} has no secret mapping"
+    assert mapping.get("api_key") or mapping.get("from_api_key"), (
+        f"Server-required tab {tab_key} has no api_key/from_api_key route"
+    )

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -453,7 +453,7 @@ def test_save_config_uses_profile_path_without_env_override(tmp_path, monkeypatc
     not sys.platform.startswith("linux"),
     reason="XDG_CONFIG_HOME is honored only on Linux",
 )
-def test_linux_xdg_save_server_details_roundtrip(tmp_path, monkeypatch):
+def test_linux_xdg_save_server_details_roundtrip(qapp, tmp_path, monkeypatch):
     """Regression: GUI save must persist server URL and API key under Linux XDG profile paths."""
     from unittest.mock import patch
 
@@ -502,7 +502,7 @@ def test_linux_xdg_save_server_details_roundtrip(tmp_path, monkeypatch):
     not sys.platform.startswith("linux"),
     reason="XDG_CONFIG_HOME is honored only on Linux",
 )
-def test_linux_xdg_save_configuration_roundtrip(tmp_path, monkeypatch):
+def test_linux_xdg_save_configuration_roundtrip(qapp, tmp_path, monkeypatch):
     """Regression: File → Save persists server URL via save_server_details when dirty."""
     from unittest.mock import patch
 

--- a/tests/test_plan_invariants.py
+++ b/tests/test_plan_invariants.py
@@ -1,0 +1,149 @@
+"""CLI invariant guardrails: behavior that must *always* remain true regardless
+of implementation changes an AI agent might make.
+
+These verify structural properties of every ``CommandPlan`` produced by
+``build_plan_from_state``: correct command prefix, single dry-run emission,
+from-dry-run scoping, and absolute path positionals.
+"""
+
+import os
+
+import pytest
+
+from core.cli_schema import TAB_COMMANDS
+from core.command_builder import build_plan_from_state, collect_paths
+from core.flag_registry import REGISTRY
+
+IMMICH_SOURCE_TABS = ("upload-immich", "archive-immich")
+
+
+def _config_state():
+    return {
+        "server": "http://localhost:2283",
+        "api_key": "k",
+        "admin_api_key": "a",
+        "skip-ssl": False,
+        "client_timeout_minutes": 60,
+    }
+
+
+def _tab_state(tab_key, tmp_path):
+    state: dict = {}
+    if tab_key != "stack" and tab_key != "archive-immich":
+        state["path"] = str(tmp_path / "src")
+    if tab_key in (
+        "archive-folder",
+        "archive-gp",
+        "archive-icloud",
+        "archive-picasa",
+        "archive-immich",
+    ):
+        state["write-to"] = str(tmp_path / "out")
+    if tab_key in IMMICH_SOURCE_TABS:
+        state["from-server"] = "http://src:2283"
+        state["from-api-key"] = "fk"
+    return state
+
+
+@pytest.mark.parametrize("tab_key", sorted(REGISTRY.tabs))
+def test_plan_starts_with_tab_command(tab_key, tmp_path):
+    """Every plan must begin with the registered subcommand prefix."""
+    plan = build_plan_from_state(
+        tab_key=tab_key,
+        config_state=_config_state(),
+        tab_state=_tab_state(tab_key, tmp_path),
+        binary_path="./immich-go",
+        base_env={},
+    )
+    assert not plan.errors, plan.errors
+    expected = TAB_COMMANDS[tab_key]
+    assert plan.argv[: len(expected)] == expected, (
+        f"{tab_key}: expected prefix {expected}, got {plan.argv}"
+    )
+
+
+@pytest.mark.parametrize("tab_key", sorted(REGISTRY.tabs))
+def test_plan_argv_excludes_binary_path(tab_key, tmp_path):
+    """argv must contain only the subcommand + flags + positionals.
+
+    The binary path is prepended only in display_argv, never in the argv that
+    is passed to the terminal launcher (which receives the binary separately).
+    """
+    plan = build_plan_from_state(
+        tab_key=tab_key,
+        config_state=_config_state(),
+        tab_state=_tab_state(tab_key, tmp_path),
+        binary_path="./immich-go",
+        base_env={},
+    )
+    assert plan.argv[0] != "./immich-go", (
+        f"{tab_key}: binary path leaked into argv: {plan.argv}"
+    )
+
+
+def test_dry_run_emitted_once_when_enabled(tmp_path):
+    plan = build_plan_from_state(
+        tab_key="upload-folder",
+        config_state=_config_state(),
+        tab_state={"path": str(tmp_path / "src")},
+        binary_path="./immich-go",
+        dry_run=True,
+        base_env={},
+    )
+    dry = [a for a in plan.argv if a == "--dry-run" or a.startswith("--dry-run=")]
+    assert len(dry) == 1, f"Expected one --dry-run, got {dry}"
+
+
+def test_dry_run_not_emitted_when_disabled(tmp_path):
+    plan = build_plan_from_state(
+        tab_key="upload-folder",
+        config_state=_config_state(),
+        tab_state={"path": str(tmp_path / "src")},
+        binary_path="./immich-go",
+        dry_run=False,
+        base_env={},
+    )
+    assert not any(a == "--dry-run" or a.startswith("--dry-run=") for a in plan.argv)
+
+
+@pytest.mark.parametrize("tab_key", sorted(REGISTRY.tabs))
+def test_from_dry_run_scoped_to_immich_source_tabs(tab_key, tmp_path):
+    """--from-dry-run may only appear for upload-immich/archive-immich."""
+    plan = build_plan_from_state(
+        tab_key=tab_key,
+        config_state=_config_state(),
+        tab_state=_tab_state(tab_key, tmp_path),
+        binary_path="./immich-go",
+        dry_run=True,
+        base_env={},
+    )
+    has = any(a == "--from-dry-run" for a in plan.argv)
+    if tab_key in IMMICH_SOURCE_TABS:
+        assert has, f"{tab_key} should emit --from-dry-run with dry_run"
+    else:
+        assert not has, f"{tab_key} must not emit --from-dry-run: {plan.argv}"
+
+
+def test_unknown_tab_produces_error():
+    plan = build_plan_from_state(
+        tab_key="does-not-exist",
+        config_state={},
+        tab_state={},
+        binary_path="./immich-go",
+        base_env={},
+    )
+    assert plan.errors, "Unknown tab should produce a plan error"
+
+
+def test_collect_paths_returns_absolute_paths():
+    """Path positionals must always be absolute (glob-expanded + abspath)."""
+    result = collect_paths("nonexistent_alpha\nnonexistent_beta")
+    assert len(result) == 2
+    assert all(os.path.isabs(p) for p in result)
+
+
+def test_collect_paths_expands_tilde_to_absolute():
+    result = collect_paths("~/nonexistent_home_path")
+    assert len(result) == 1
+    assert os.path.isabs(result[0])
+    assert "~" not in result[0]

--- a/tests/test_secret_safety.py
+++ b/tests/test_secret_safety.py
@@ -1,0 +1,121 @@
+"""Security guardrails: secrets must never leak into argv, display previews,
+or anywhere a shell/process could expose them.
+
+API keys are delivered exclusively via ``IMMICH_GO_*`` environment variables
+(see ``build_environment``). These tests lock that invariant in so an AI agent
+cannot regress it by accidentally emitting ``--api-key=<value>``.
+"""
+
+import pytest
+
+from core.command_builder import build_plan_from_state
+from core.flag_registry import REGISTRY
+
+SECRET_API_KEY = "super-secret-api-key-12345"
+SECRET_ADMIN_KEY = "admin-secret-key-67890"
+SECRET_FROM_KEY = "from-source-secret-key-abcde"
+ALL_SECRETS = (SECRET_API_KEY, SECRET_ADMIN_KEY, SECRET_FROM_KEY)
+
+IMMICH_SOURCE_TABS = ("upload-immich", "archive-immich")
+
+
+def _config_state():
+    return {
+        "server": "http://localhost:2283",
+        "api_key": SECRET_API_KEY,
+        "admin_api_key": SECRET_ADMIN_KEY,
+        "skip-ssl": False,
+        "client_timeout_minutes": 60,
+    }
+
+
+def _tab_state(tab_key, tmp_path):
+    path = str(tmp_path / "src")
+    out = str(tmp_path / "out")
+    state: dict = {}
+    if tab_key in (
+        "archive-folder",
+        "archive-gp",
+        "archive-icloud",
+        "archive-picasa",
+        "archive-immich",
+    ):
+        state["write-to"] = out
+    if tab_key != "archive-immich":
+        state["path"] = path
+    if tab_key in IMMICH_SOURCE_TABS:
+        state["from-server"] = "http://source:2283"
+        state["from-api-key"] = SECRET_FROM_KEY
+        state["from-admin-api-key"] = SECRET_ADMIN_KEY
+    return state
+
+
+@pytest.mark.parametrize("tab_key", sorted(REGISTRY.server_required_tabs))
+def test_secrets_never_in_argv(tab_key, tmp_path):
+    """No secret value may appear in the executable argv list."""
+    plan = build_plan_from_state(
+        tab_key=tab_key,
+        config_state=_config_state(),
+        tab_state=_tab_state(tab_key, tmp_path),
+        binary_path="./immich-go",
+        base_env={},
+    )
+    assert not plan.errors, plan.errors
+    joined = " ".join(plan.argv)
+    for secret in ALL_SECRETS:
+        assert secret not in joined, (
+            f"Secret leaked into argv for {tab_key}: {secret!r}\nargv={plan.argv}"
+        )
+
+
+@pytest.mark.parametrize("tab_key", sorted(REGISTRY.server_required_tabs))
+def test_secrets_never_in_display_argv(tab_key, tmp_path):
+    """No secret value may appear in the display/preview argv list."""
+    plan = build_plan_from_state(
+        tab_key=tab_key,
+        config_state=_config_state(),
+        tab_state=_tab_state(tab_key, tmp_path),
+        binary_path="./immich-go",
+        base_env={},
+    )
+    assert not plan.errors, plan.errors
+    joined = " ".join(plan.display_argv)
+    for secret in ALL_SECRETS:
+        assert secret not in joined, (
+            f"Secret leaked into display_argv for {tab_key}: {secret!r}\n"
+            f"display_argv={plan.display_argv}"
+        )
+
+
+@pytest.mark.parametrize("tab_key", sorted(REGISTRY.server_required_tabs))
+def test_secrets_delivered_via_env(tab_key, tmp_path):
+    """Secrets must be present in the env dict (delivered to the process)."""
+    plan = build_plan_from_state(
+        tab_key=tab_key,
+        config_state=_config_state(),
+        tab_state=_tab_state(tab_key, tmp_path),
+        binary_path="./immich-go",
+        base_env={},
+    )
+    assert not plan.errors, plan.errors
+    env_values = set(plan.env.values())
+    assert any(s in env_values for s in ALL_SECRETS), (
+        f"No secret delivered via env for {tab_key}: {plan.env}"
+    )
+
+
+@pytest.mark.parametrize("tab_key", sorted(REGISTRY.serverless_tabs))
+def test_serverless_tabs_never_receive_api_key_env(tab_key, tmp_path):
+    """Serverless tabs must not route API keys into the env dict."""
+    plan = build_plan_from_state(
+        tab_key=tab_key,
+        config_state=_config_state(),
+        tab_state={"path": str(tmp_path / "src"), "write-to": str(tmp_path / "out")},
+        binary_path="./immich-go",
+        base_env={},
+    )
+    assert not plan.errors, plan.errors
+    for secret in ALL_SECRETS:
+        assert secret not in plan.env.values(), (
+            f"Serverless tab {tab_key} received a secret in env: {plan.env}"
+        )

--- a/tests/test_serverless_invariants.py
+++ b/tests/test_serverless_invariants.py
@@ -1,0 +1,63 @@
+"""Invariant: serverless archive tabs must never emit server-related flags.
+
+This enforces the architectural rule from AGENTS.md §3: serverless archive
+tabs (archive-folder, archive-gp, archive-icloud, archive-picasa) must never
+emit ``--server``, ``--api-key``, ``--admin-api-key``, or ``--client-timeout``.
+"""
+
+import pytest
+
+from core.command_builder import build_plan_from_state
+from core.flag_registry import REGISTRY
+
+SERVER_FLAGS = ("--server", "--api-key", "--admin-api-key", "--client-timeout")
+
+
+@pytest.mark.parametrize("tab_key", sorted(REGISTRY.serverless_tabs))
+def test_serverless_tab_never_emits_server_flags(tab_key, tmp_path):
+    """Even when server/api-key are present in config, serverless tabs must
+    not emit any server-related CLI flag."""
+    plan = build_plan_from_state(
+        tab_key=tab_key,
+        config_state={
+            "server": "http://should-not-appear:2283",
+            "api_key": "should-not-appear-key",
+            "admin_api_key": "should-not-appear-admin",
+            "skip-ssl": False,
+            "client_timeout_minutes": 60,
+        },
+        tab_state={
+            "path": str(tmp_path / "src"),
+            "write-to": str(tmp_path / "out"),
+        },
+        binary_path="./immich-go",
+        base_env={},
+    )
+    assert not plan.errors, plan.errors
+    joined = " ".join(plan.argv)
+    for flag in SERVER_FLAGS:
+        assert flag not in joined, (
+            f"Serverless tab {tab_key} emitted {flag}: {plan.argv}"
+        )
+
+
+@pytest.mark.parametrize("tab_key", sorted(REGISTRY.serverless_tabs))
+def test_serverless_tab_starts_with_archive_command(tab_key, tmp_path):
+    """Every serverless plan must start with the archive subcommand."""
+    from core.cli_schema import TAB_COMMANDS
+
+    plan = build_plan_from_state(
+        tab_key=tab_key,
+        config_state={},
+        tab_state={
+            "path": str(tmp_path / "src"),
+            "write-to": str(tmp_path / "out"),
+        },
+        binary_path="./immich-go",
+        base_env={},
+    )
+    assert not plan.errors, plan.errors
+    expected = TAB_COMMANDS[tab_key]
+    assert plan.argv[: len(expected)] == expected, (
+        f"{tab_key}: expected prefix {expected}, got {plan.argv}"
+    )


### PR DESCRIPTION
## What

Adds 7 new guardrail test files that enforce architectural invariants (from the ai-agent-testing / test-optimization analysis), optimizes the test suite, and fixes CI so that **PRs targeting any base branch** receive checks.

> ⚠️ **Stacked on #110** (`feat/pyrefly-ty-ruff`) — merge #110 first, then this PR's diff will narrow to only its own changes.

## Guardrail tests (new)

| File | Enforces |
|---|---|
| `tests/test_architecture.py` | `core/` stays Qt-free (AST walk, no `PySide6`) |
| `tests/test_flags_toml_schema.py` | `flags.toml` SSOT schema invariants (valid kinds, sections, serverless exclusivity, no dup keys) |
| `tests/test_secret_safety.py` | Secrets only in `plan.env`, never in `plan.argv` / `display_argv` |
| `tests/test_plan_invariants.py` | CLI plan invariants parametrized over all tabs |
| `tests/test_serverless_invariants.py` | Serverless tabs never emit server flags |
| `tests/test_advanced_flag_emission.py` | Advanced flags emit when enabled / not when disabled |
| `tests/test_cli_contract.py` | Unknown/removed/renamed flag guards |

## Test suite optimization

- `conftest.py`: session `gui` fixture now stops **all** background timers (`_conn_test_debounce`, `_status_debounce`, `_cleanup_timer`, `binary_debounce`)
- `conftest.py`: `_reset_client_timeout` / `_reset_shared_config` are conditional on `gui` usage — pure-core tests no longer construct the full window
- `conftest.py`: new autouse `_block_network` fixture denies real network calls
- `pyproject.toml`: registered the `live_cli`, `gui`, `theme`, `security`, `unit`, `slow` markers; default run excludes `integration` + `live_cli`
- `test_flag_registry.py`: `test_bool_defaults_match_live_cli` marked `live_cli`
- Added `qapp` fixture where Qt event processing is required (`test_app_update.py`, `test_diagnostics.py`, `test_persistence.py`)

## CI fix (no PR checks on non-master base)

PRs opened against a base branch other than `master` (e.g. `staging`) silently got **zero** CI checks because `pr-fast-feedback.yml` and `codeql.yml` filtered `pull_request` to `branches: [master]`. Removed those filters — CI now runs on PRs targeting any base branch.

Also pinned ruff lint rules to `E4, E7, E9, F` (the rules the codebase was developed against) so the expanded ruff 0.16 defaults don't surface ~116 violations when the pre-commit hook `rev` was bumped `v0.9.9 → v0.16.0`.

## Verification

- Full suite: **406 passed, 10 skipped, 7 deselected** in ~38s
- `live_cli` test passes when run explicitly (`-m live_cli`)
- All pre-commit hooks pass (ruff 0.16, ty-check, version/test-count sync)
- Docs test counts synced: 271 → **423 tests / 27 modules**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Quality and Reliability**
  - Expanded automated coverage for command generation, configuration validation, secret handling, serverless operation, persistence, and architecture boundaries.
  - Improved test isolation by preventing unintended network requests and ensuring GUI-related tests initialize and clean up reliably.
  - Added safeguards to prevent secrets from appearing in commands or display output.

- **Developer Documentation**
  - Updated testing documentation and metrics to reflect the broader test suite.
  - Clarified test categories and default test selection.

- **Workflow Improvements**
  - CI checks now run for pull requests targeting any branch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->