### PR TITLE
fix(ci): update workflow tag triggers to match Release Please immich-go-gui-v* format

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,7 +3,8 @@ name: Deploy Docs to GitHub Pages
 on:
   push:
     tags:
-      - 'v[0-9]*'
+      - 'immich-go-gui-v[0-9]*'  # Release Please tag format (since v1.2.0)
+      - 'v[0-9]*'                 # Legacy tag format (v0.9.x – v1.1.x)
   workflow_dispatch:
 
 permissions:
@@ -69,13 +70,19 @@ jobs:
 
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v5
-        if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/')
+        if: |
+          github.event_name == 'workflow_dispatch' ||
+          startsWith(github.ref, 'refs/tags/immich-go-gui-v') ||
+          startsWith(github.ref, 'refs/tags/v')
         with:
           path: site/
 
   deploy:
     needs: build
-    if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/')
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      startsWith(github.ref, 'refs/tags/immich-go-gui-v') ||
+      startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     environment:
       name: github-pages

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,8 @@ on:
         default: '1.0.0-test'
   push:
     tags:
-      - 'v[0-9]*'
+      - 'immich-go-gui-v[0-9]*'  # Release Please tag format (since v1.2.0)
+      - 'v[0-9]*'                 # Legacy tag format (v0.9.x – v1.1.x)
 
 env:
   CREATE_DMG_VERSION: '8.1.0'
@@ -73,7 +74,10 @@ jobs:
           if [[ "${{ github.event_name }}" == "workflow_dispatch" && -n "${{ github.event.inputs.version }}" ]]; then
             VERSION="${{ github.event.inputs.version }}"
           else
-            VERSION=${GITHUB_REF_NAME#v}
+            # Strip Release Please prefix (immich-go-gui-v1.3.0 -> 1.3.0)
+            # or legacy bare prefix (v1.0.0 -> 1.0.0)
+            VERSION=${GITHUB_REF_NAME#immich-go-gui-v}
+            VERSION=${VERSION#v}
             if [[ "$VERSION" == *"/"* ]] || [[ -z "$VERSION" ]]; then VERSION="1.0.0-test"; fi
           fi
           echo "VERSION=$VERSION" >> $GITHUB_ENV


### PR DESCRIPTION
## Problem

Since `package-name` is set in `release-please-config.json`, Release Please creates tags like `immich-go-gui-v1.3.0` instead of bare `v1.3.0`. Both `docs.yml` and `release.yml` only matched `v[0-9]*`, so **neither workflow has fired on any release since v1.2.0**.

This is why the v1.3.0 docs deploy and release build never ran.

## Changes

- **`docs.yml`**: added `immich-go-gui-v[0-9]*` tag trigger; updated upload/deploy job conditionals to match both tag prefixes
- **`release.yml`**: added `immich-go-gui-v[0-9]*` tag trigger; fixed `VERSION` extraction to strip `immich-go-gui-v` prefix before `v` prefix (so artifact filenames still get plain `1.3.0`)

Legacy `v[0-9]*` kept on both triggers for backward compat with v0.9.x–v1.1.x tags.

## After merging

Manually dispatch **Deploy Docs to GitHub Pages** and **Build and Release Apps** from the GitHub Actions UI to cover the missed v1.3.0 run. No new tag needed — both workflows support `workflow_dispatch`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release and documentation publishing workflows to support both current and legacy release tag formats.
  * Improved version handling when publishing build artifacts and releases.
  * Restricted artifact uploads and deployments to approved release tags or manual workflow runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->