### PR TITLE
feat(ci): streamline release workflows to bare v<version> tags

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -3,7 +3,6 @@
   "packages": {
     ".": {
       "release-type": "python",
-      "package-name": "immich-go-gui",
       "changelog-path": "CHANGELOG.md",
       "bump-minor-pre-major": false,
       "bump-patch-for-minor-pre-major": false,

--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -3,6 +3,7 @@
   "packages": {
     ".": {
       "release-type": "python",
+      "include-component-in-tag": false,
       "changelog-path": "CHANGELOG.md",
       "bump-minor-pre-major": false,
       "bump-patch-for-minor-pre-major": false,

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,11 +23,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up Python
-        uses: actions/setup-python@v7
-        with:
-          python-version: '3.13'
-
       - name: Install uv
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,8 +3,7 @@ name: Deploy Docs to GitHub Pages
 on:
   push:
     tags:
-      - 'immich-go-gui-v[0-9]*'  # Release Please tag format (since v1.2.0)
-      - 'v[0-9]*'                 # Legacy tag format (v0.9.x – v1.1.x)
+      - 'v[0-9]*'
   workflow_dispatch:
 
 permissions:
@@ -70,19 +69,13 @@ jobs:
 
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v5
-        if: |
-          github.event_name == 'workflow_dispatch' ||
-          startsWith(github.ref, 'refs/tags/immich-go-gui-v') ||
-          startsWith(github.ref, 'refs/tags/v')
+        if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/')
         with:
           path: site/
 
   deploy:
     needs: build
-    if: |
-      github.event_name == 'workflow_dispatch' ||
-      startsWith(github.ref, 'refs/tags/immich-go-gui-v') ||
-      startsWith(github.ref, 'refs/tags/v')
+    if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     environment:
       name: github-pages

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,8 +9,7 @@ on:
         default: '1.0.0-test'
   push:
     tags:
-      - 'immich-go-gui-v[0-9]*'  # Release Please tag format (since v1.2.0)
-      - 'v[0-9]*'                 # Legacy tag format (v0.9.x – v1.1.x)
+      - 'v[0-9]*'
 
 env:
   CREATE_DMG_VERSION: '8.1.0'
@@ -74,10 +73,7 @@ jobs:
           if [[ "${{ github.event_name }}" == "workflow_dispatch" && -n "${{ github.event.inputs.version }}" ]]; then
             VERSION="${{ github.event.inputs.version }}"
           else
-            # Strip Release Please prefix (immich-go-gui-v1.3.0 -> 1.3.0)
-            # or legacy bare prefix (v1.0.0 -> 1.0.0)
-            VERSION=${GITHUB_REF_NAME#immich-go-gui-v}
-            VERSION=${VERSION#v}
+            VERSION=${GITHUB_REF_NAME#v}
             if [[ "$VERSION" == *"/"* ]] || [[ -z "$VERSION" ]]; then VERSION="1.0.0-test"; fi
           fi
           echo "VERSION=$VERSION" >> $GITHUB_ENV


### PR DESCRIPTION
## Summary

Streamlines the Release Please configuration and GitHub Actions release workflows so all future releases use standard bare `v<version>` tags (e.g. `v1.4.0`).

## Changes

1. **`release-please-config.json`**: Removed `"package-name": "immich-go-gui"` so Release Please generates bare `v<version>` tags (e.g. `v1.4.0`) instead of component-prefixed tags.
2. **`docs.yml`**: Set trigger exclusively to `v[0-9]*` tag pushes and `workflow_dispatch`.
3. **`release.yml`**: Set trigger exclusively to `v[0-9]*` tag pushes and simplified `VERSION` extraction to `${GITHUB_REF_NAME#v}`.

## Verification

- `uv run pre-commit run --all-files` passed.
- `uv run python scripts/sync_version.py --check` passed.
- `uv run ty check core/` passed.
- `uv run python app.py --self-test` passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Simplified release configuration for clearer version tagging.
  - Standardized release and documentation publishing around version tags beginning with `v`.
  - Improved version recognition for tagged releases.
  - Updated documentation publishing to support both tagged releases and manual runs.
  - Streamlined deployment conditions to make publishing behavior more predictable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->