### PR TITLE
fix(ci): fix release-please extra-files to use x-release-please-version markers

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -12,15 +12,11 @@
       "extra-files": [
         {
           "type": "generic",
-          "path": "docs/README.md",
-          "match": "Docs track the application as of <strong>v[^<]+</strong>",
-          "replacement": "Docs track the application as of <strong>v${version}</strong>"
+          "path": "docs/README.md"
         },
         {
           "type": "generic",
-          "path": "docs/developer-guide/ci-cd-and-releases.md",
-          "match": "Current version is defined in `pyproject.toml` \\(e\\.g\\. `[^`]+`\\)\\.",
-          "replacement": "Current version is defined in `pyproject.toml` (e.g. `${version}`)."
+          "path": "docs/developer-guide/ci-cd-and-releases.md"
         }
       ],
       "changelog-sections": [

--- a/docs/README.md
+++ b/docs/README.md
@@ -314,5 +314,5 @@ flowchart TB
 
 <div class="version-banner">
   <strong>Version note:</strong>
-  <span>Docs track the application as of <strong>v1.3.0</strong>, tested with <strong>immich-go 0.32.0</strong>. If something in the UI disagrees with a page, prefer the running app and open an issue or PR.</span>
+  <span>Docs track the application as of <strong>v1.3.0<!-- x-release-please-version --></strong>, tested with <strong>immich-go 0.32.0</strong>. If something in the UI disagrees with a page, prefer the running app and open an issue or PR.</span>
 </div>

--- a/docs/developer-guide/ci-cd-and-releases.md
+++ b/docs/developer-guide/ci-cd-and-releases.md
@@ -32,7 +32,7 @@ When merging to `master`, Release Please opens a version bump PR. On merge, it c
 
 **Important:** Update `.github/.release-please-manifest.json` when performing manual version bumps so Release Please tracks the correct baseline.
 
-Current version is defined in `pyproject.toml` (e.g. `1.3.0`).
+Current version is defined in `pyproject.toml` (e.g. `1.3.0`<!-- x-release-please-version -->).
 
 ## Release Artifacts
 

--- a/scripts/sync_version.py
+++ b/scripts/sync_version.py
@@ -131,13 +131,13 @@ def main() -> int:
         ),
         (
             ROOT_DIR / "docs" / "README.md",
-            r"Docs track the application as of <strong>v[^<]+</strong>",
-            "Docs track the application as of <strong>v{version}</strong>",
+            r"Docs track the application as of <strong>v[^<]+<!-- x-release-please-version --></strong>",
+            "Docs track the application as of <strong>v{version}<!-- x-release-please-version --></strong>",
         ),
         (
             ROOT_DIR / "docs" / "developer-guide" / "ci-cd-and-releases.md",
-            r"Current version is defined in `pyproject.toml` \(e\.g\. `[^`]+`\)\.",
-            "Current version is defined in `pyproject.toml` (e.g. `{version}`).",
+            r"Current version is defined in `pyproject.toml` \(e\.g\. `[^`]+`<!-- x-release-please-version -->\)\.",
+            "Current version is defined in `pyproject.toml` (e.g. `{version}`<!-- x-release-please-version -->).",
         ),
         (
             ROOT_DIR / "docs" / "developer-guide" / "ci-cd-and-releases.md",


### PR DESCRIPTION
## Problem / Root Cause

In PR #117 (Release Please PR for 1.4.0), the `Version Sync Check` failed because `docs/README.md` and `docs/developer-guide/ci-cd-and-releases.md` were not updated to 1.4.0.

### Why didn't Release Please update extra-files?
The previous configuration in `.github/release-please-config.json` specified custom `match` and `replacement` regex fields for `extra-files`. However, **Release Please's `generic` updater does not use custom regex match/replacement strings**.

Instead, the `generic` updater scans files for inline HTML comment markers like `<!-- x-release-please-version -->` (or `# x-release-please-version`). Because those markers were missing from the documentation files, Release Please could not locate the version strings and silently skipped them during release PR generation.

## Solution

1. **Annotate Documentation Files**:
   - Added `<!-- x-release-please-version -->` to `docs/README.md` version string.
   - Added `<!-- x-release-please-version -->` to `docs/developer-guide/ci-cd-and-releases.md` version string.

2. **Clean up Release Please Config**:
   - Simplified `.github/release-please-config.json` to standard `generic` type entries (specifying paths only).

3. **Update Local Sync Tool**:
   - Updated `scripts/sync_version.py` regex patterns to preserve the HTML markers when checking or syncing versions.

## Verification
- Local `uv run python scripts/sync_version.py --check` passes.
- Local `uv run pre-commit run --all-files` passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added release-version markers to the application README and CI/CD release guide.
  - Updated documented version examples to remain compatible with automated release updates.
- **Chores**
  - Improved release automation so documentation versions are updated consistently while preserving required markers.
  - Simplified version tracking configuration for documentation files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->