### PR TITLE
fix(ci): use RELEASE_PLEASE_TOKEN PAT for Release Please action

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           config-file: .github/release-please-config.json
           manifest-file: .github/.release-please-manifest.json
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
 
       # Release Please creates the semver tag (e.g. v1.2.0); release.yml already
       # triggers on tag push v[0-9]*. Do not also dispatch release.yml here —


### PR DESCRIPTION
## Problem
Tags created by Release Please using default `GITHUB_TOKEN` do not trigger downstream `push: tags:` workflows (`release.yml` and `docs.yml`) due to GitHub security restrictions preventing recursive workflow execution.

## Solution
Update `.github/workflows/release-please.yml` to use `secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN`.

With `RELEASE_PLEASE_TOKEN` configured in repo secrets, tags pushed by Release Please automatically trigger:
- `release.yml` to build and upload release assets per-platform
- `docs.yml` to build and deploy MkDocs to GitHub Pages

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release automation authentication by preferring the dedicated release token and falling back to the standard repository token.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->