### PR TITLE
fix(ci): remove macos-13 x86_64 runner due to runner capacity timeouts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,8 +59,6 @@ jobs:
             name: linux
           - os: windows-latest
             name: windows
-          - os: macos-13
-            name: macos
           - os: macos-latest
             name: macos
 


### PR DESCRIPTION
## Summary
Removes the `macos-13` (Intel x86_64) runner entry from the `release.yml` build matrix.

## Rationale
GitHub Actions `macos-13` runner instances frequently experience queue capacity constraints, causing release workflows to stall in queue or fail due to 12-hour job execution timeouts. Modern macOS builds continue to run on `macos-latest` (Apple Silicon / ARM64).

## Verification
- `uv run python scripts/sync_version.py --check`: **PASSED**
- `uv run python scripts/sync_test_count.py --check`: **PASSED**
- `uv run ty check core/`: **PASSED**
- `uv run python app.py --self-test`: **PASSED**
- `uv run pre-commit run --all-files`: **PASSED**