### PR TITLE
fix(ci): switch release asset upload to native gh release CLI to prevent API race conditions

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -25,7 +25,7 @@ Authoritative context for AI agents working in this repository. When user-provid
 | **Self-test** | `uv run python app.py --self-test` — loads registry, builds a plan, checks config dir |
 | **pre-commit** | `uv run pre-commit run --all-files` — mandatory check before committing or creating PRs |
 | **githooks** | Native git hooks in `.githooks/` configured via `git config core.hooksPath .githooks` |
-| **githooks** | Native git hooks in `.githooks/` configured via `git config core.hooksPath .githooks` |
+| **subshell/env** | On first command, initialize a persistent terminal (`RunPersistent: true`) with `export PATH="$HOME/.local/bin:$HOME/.cargo/bin:$PATH"; unset GITHUB_TOKEN GH_TOKEN; export GH_PROMPT_DISABLED=1 NO_COLOR=1` and reuse `TerminalID` across commands to avoid repetitive prefixes and token bloat. |
 
 ### Git Branching
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v7
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -53,7 +53,7 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v7
+        uses: actions/checkout@v4
 
       - name: Setup uv
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
@@ -82,7 +82,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v7
+        uses: actions/checkout@v4
 
       - name: Setup uv
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,8 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Setup uv
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
@@ -83,6 +85,8 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Setup uv
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,9 +9,10 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup uv
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
@@ -53,7 +54,7 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
 
@@ -84,7 +85,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -21,7 +21,9 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
+      with:
+        persist-credentials: false
 
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v4.37.6

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v7
+      uses: actions/checkout@v4
 
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v4.37.6

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,9 +19,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Install uv
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,7 +19,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/manual-prerelease.yml
+++ b/.github/workflows/manual-prerelease.yml
@@ -119,7 +119,10 @@ jobs:
         run: xvfb-run uv run pytest
 
       - name: Create and Push Tag
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          gh auth setup-git
           PRERELEASE_VERSION="${{ steps.version.outputs.prerelease_version }}"
           SHORT_COMMIT=$(git rev-parse --short HEAD)
 

--- a/.github/workflows/manual-prerelease.yml
+++ b/.github/workflows/manual-prerelease.yml
@@ -49,10 +49,11 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.event.inputs.branch }}
           fetch-depth: 0
+          persist-credentials: false
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup uv

--- a/.github/workflows/manual-prerelease.yml
+++ b/.github/workflows/manual-prerelease.yml
@@ -49,7 +49,7 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v7
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.inputs.branch }}
           fetch-depth: 0

--- a/.github/workflows/pr-fast-feedback.yml
+++ b/.github/workflows/pr-fast-feedback.yml
@@ -26,9 +26,10 @@ jobs:
       has_sync_relevant_changes: ${{ steps.check.outputs.has_sync_relevant_changes }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Check for code changes
         id: check
@@ -81,7 +82,9 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Setup uv
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
@@ -113,7 +116,7 @@ jobs:
     if: needs.analyze-changes.outputs.has_code_changes == 'true' || needs.analyze-changes.outputs.has_sync_relevant_changes == 'true'
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -158,7 +161,9 @@ jobs:
     if: needs.analyze-changes.outputs.has_code_changes == 'true'
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Setup uv
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0

--- a/.github/workflows/pr-fast-feedback.yml
+++ b/.github/workflows/pr-fast-feedback.yml
@@ -26,7 +26,7 @@ jobs:
       has_sync_relevant_changes: ${{ steps.check.outputs.has_sync_relevant_changes }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -81,7 +81,7 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v7
+        uses: actions/checkout@v4
 
       - name: Setup uv
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
@@ -113,7 +113,7 @@ jobs:
     if: needs.analyze-changes.outputs.has_code_changes == 'true' || needs.analyze-changes.outputs.has_sync_relevant_changes == 'true'
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v7
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -158,7 +158,7 @@ jobs:
     if: needs.analyze-changes.outputs.has_code_changes == 'true'
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v7
+        uses: actions/checkout@v4
 
       - name: Setup uv
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -221,4 +221,5 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         shell: bash
         run: |
-          gh release create "test-${{ env.VERSION }}" Immich-Go-GUI-${{ env.VERSION }}-* --title "Test Build test-${{ env.VERSION }}" --prerelease --clobber 2>/dev/null || gh release upload "test-${{ env.VERSION }}" Immich-Go-GUI-${{ env.VERSION }}-* --clobber
+          gh release upload "test-${{ env.VERSION }}" Immich-Go-GUI-${{ env.VERSION }}-* --clobber || \
+          gh release create "test-${{ env.VERSION }}" Immich-Go-GUI-${{ env.VERSION }}-* --title "Test Build test-${{ env.VERSION }}" --target "${{ github.sha }}" --prerelease

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,8 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Setup uv
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
@@ -65,6 +67,8 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Set Version
         id: set-version
@@ -79,6 +83,7 @@ jobs:
             if [[ "$VERSION" == *"/"* ]] || [[ -z "$VERSION" ]]; then VERSION="1.0.0-test"; fi
           fi
           VERSION=$(echo "$VERSION" | tr -cd 'a-zA-Z0-9.-')
+          if [ -z "$VERSION" ]; then VERSION="1.0.0-test"; fi
           echo "VERSION=$VERSION" >> $GITHUB_ENV
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
@@ -89,7 +94,7 @@ jobs:
         run: uv sync --dev
 
       - name: Setup Ccache
-        uses: hendrikmuhs/ccache-action@v1.2.23
+        uses: hendrikmuhs/ccache-action@d62db5f07c26379fc4b4e0916f098a92573c3b03 # v1.2.23
         with:
           key: ${{ runner.os }}-ccache-${{ matrix.name }}-${{ hashFiles('pyproject.toml', 'app.py', 'core/**') }}
           restore-keys: |
@@ -236,16 +241,20 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/')
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ github.ref_name }}
         shell: bash
         run: |
-          gh release upload "${{ github.ref_name }}" Immich-Go-GUI-${{ env.VERSION }}-* --clobber 2>/dev/null || \
-          gh release create "${{ github.ref_name }}" Immich-Go-GUI-${{ env.VERSION }}-* --title "${{ github.ref_name }}" --clobber
+          gh release upload "$RELEASE_TAG" Immich-Go-GUI-${{ env.VERSION }}-* --clobber 2>/dev/null || \
+          (gh release create "$RELEASE_TAG" Immich-Go-GUI-${{ env.VERSION }}-* --title "$RELEASE_TAG" 2>/dev/null || true; \
+           gh release upload "$RELEASE_TAG" Immich-Go-GUI-${{ env.VERSION }}-* --clobber)
 
       - name: Publish assets to Test Pre-Release
         if: ${{ !startsWith(github.ref, 'refs/tags/') }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: test-${{ env.VERSION }}
         shell: bash
         run: |
-          gh release upload "test-${{ env.VERSION }}" Immich-Go-GUI-${{ env.VERSION }}-* --clobber 2>/dev/null || \
-          gh release create "test-${{ env.VERSION }}" Immich-Go-GUI-${{ env.VERSION }}-* --title "Test Build test-${{ env.VERSION }}" --target "${{ github.sha }}" --prerelease
+          gh release upload "$RELEASE_TAG" Immich-Go-GUI-${{ env.VERSION }}-* --clobber 2>/dev/null || \
+          (gh release create "$RELEASE_TAG" Immich-Go-GUI-${{ env.VERSION }}-* --title "Test Build $RELEASE_TAG" --target "${{ github.sha }}" --prerelease 2>/dev/null || true; \
+           gh release upload "$RELEASE_TAG" Immich-Go-GUI-${{ env.VERSION }}-* --clobber)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,6 +88,27 @@ jobs:
       - name: Install dependencies
         run: uv sync --dev
 
+      - name: Setup Ccache
+        uses: hendrikmuhs/ccache-action@v1.2
+        with:
+          key: ${{ runner.os }}-ccache-${{ matrix.name }}-${{ hashFiles('pyproject.toml', 'app.py', 'core/**') }}
+          restore-keys: |
+            ${{ runner.os }}-ccache-${{ matrix.name }}-
+            ${{ runner.os }}-ccache-
+          max-size: 2G
+
+      - name: Cache Nuitka build directory
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/Nuitka
+            ~/Library/Caches/Nuitka
+            ${{ env.LOCALAPPDATA }}\Nuitka\Nuitka
+          key: ${{ runner.os }}-nuitka-${{ matrix.name }}-${{ hashFiles('pyproject.toml', 'app.py', 'core/**') }}
+          restore-keys: |
+            ${{ runner.os }}-nuitka-${{ matrix.name }}-
+            ${{ runner.os }}-nuitka-
+
       - name: Detect macOS architecture
         if: matrix.name == 'macos'
         id: macos-arch

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -180,9 +180,10 @@ jobs:
       - name: Build Linux AppImage
         if: matrix.name == 'linux'
         run: |
-          mkdir -p AppDir/usr/bin
+          mkdir -p AppDir/usr/bin AppDir/usr/share/metainfo
           cp -r app.dist/* AppDir/usr/bin/
           cp immich-go-gui.png AppDir/
+          cp packaging/linux/immich-go-gui.appdata.xml AppDir/usr/share/metainfo/
 
           cat << 'EOF' > AppDir/immich-go-gui.desktop
           [Desktop Entry]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,7 +98,7 @@ jobs:
           max-size: 2G
 
       - name: Cache Nuitka build directory
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: |
             ~/.cache/Nuitka

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v7
+        uses: actions/checkout@v4
 
       - name: Setup uv
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
@@ -64,7 +64,7 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v7
+        uses: actions/checkout@v4
 
       - name: Set Version
         id: set-version
@@ -89,7 +89,7 @@ jobs:
         run: uv sync --dev
 
       - name: Setup Ccache
-        uses: hendrikmuhs/ccache-action@v1.2
+        uses: hendrikmuhs/ccache-action@v1.2.23
         with:
           key: ${{ runner.os }}-ccache-${{ matrix.name }}-${{ hashFiles('pyproject.toml', 'app.py', 'core/**') }}
           restore-keys: |
@@ -152,7 +152,7 @@ jobs:
 
       - name: Setup Node.js
         if: matrix.name == 'macos'
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@v4
         with:
           node-version: '20'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -204,36 +204,21 @@ jobs:
             fi
           done
 
-      # Upload this platform's assets to the GitHub Release immediately —
-      # do not wait for other platforms. softprops/action-gh-release safely
-      # upserts the release and appends assets from concurrent jobs.
+      # Upload this platform's assets to the GitHub Release using GitHub CLI —
+      # gh release upload directly uploads matching platform files with --clobber,
+      # avoiding softprops API race condition HttpErrors on concurrent matrix jobs.
       - name: Publish assets to GitHub Release
         if: startsWith(github.ref, 'refs/tags/')
-        uses: softprops/action-gh-release@v3
-        with:
-          files: |
-            Immich-Go-GUI-${{ env.VERSION }}-Windows-x86_64-Setup.exe
-            Immich-Go-GUI-${{ env.VERSION }}-Windows-x86_64-Portable.zip
-            Immich-Go-GUI-${{ env.VERSION }}-macOS-*.dmg
-            Immich-Go-GUI-${{ env.VERSION }}-Linux-x86_64.AppImage
-            Immich-Go-GUI-${{ env.VERSION }}-Linux-x86_64-Portable.tar.gz
-            Immich-Go-GUI-${{ env.VERSION }}-Linux-x86_64.deb
-            Immich-Go-GUI-${{ env.VERSION }}-Linux-x86_64.rpm
-            Immich-Go-GUI-${{ env.VERSION }}-SHA256SUMS.txt
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          gh release upload "${{ github.ref_name }}" Immich-Go-GUI-${{ env.VERSION }}-* --clobber
 
       - name: Publish assets to Test Pre-Release
         if: ${{ !startsWith(github.ref, 'refs/tags/') }}
-        uses: softprops/action-gh-release@v3
-        with:
-          tag_name: "test-${{ env.VERSION }}"
-          name: "Test Build test-${{ env.VERSION }}"
-          prerelease: true
-          files: |
-            Immich-Go-GUI-${{ env.VERSION }}-Windows-x86_64-Setup.exe
-            Immich-Go-GUI-${{ env.VERSION }}-Windows-x86_64-Portable.zip
-            Immich-Go-GUI-${{ env.VERSION }}-macOS-*.dmg
-            Immich-Go-GUI-${{ env.VERSION }}-Linux-x86_64.AppImage
-            Immich-Go-GUI-${{ env.VERSION }}-Linux-x86_64-Portable.tar.gz
-            Immich-Go-GUI-${{ env.VERSION }}-Linux-x86_64.deb
-            Immich-Go-GUI-${{ env.VERSION }}-Linux-x86_64.rpm
-            Immich-Go-GUI-${{ env.VERSION }}-SHA256SUMS.txt
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          gh release create "test-${{ env.VERSION }}" Immich-Go-GUI-${{ env.VERSION }}-* --title "Test Build test-${{ env.VERSION }}" --prerelease --clobber 2>/dev/null || gh release upload "test-${{ env.VERSION }}" Immich-Go-GUI-${{ env.VERSION }}-* --clobber

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -155,7 +155,7 @@ jobs:
 
       - name: Setup Node.js
         if: matrix.name == 'macos'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: '20'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,14 +68,17 @@ jobs:
 
       - name: Set Version
         id: set-version
+        env:
+          INPUT_VERSION: ${{ github.event.inputs.version }}
         shell: bash
         run: |
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" && -n "${{ github.event.inputs.version }}" ]]; then
-            VERSION="${{ github.event.inputs.version }}"
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" && -n "$INPUT_VERSION" ]]; then
+            VERSION="$INPUT_VERSION"
           else
             VERSION=${GITHUB_REF_NAME#v}
             if [[ "$VERSION" == *"/"* ]] || [[ -z "$VERSION" ]]; then VERSION="1.0.0-test"; fi
           fi
+          VERSION=$(echo "$VERSION" | tr -cd 'a-zA-Z0-9.-')
           echo "VERSION=$VERSION" >> $GITHUB_ENV
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
@@ -196,10 +199,10 @@ jobs:
       - name: Generate SHA256 checksums
         shell: bash
         run: |
-          SUMS_FILE="Immich-Go-GUI-${{ env.VERSION }}-SHA256SUMS.txt"
+          SUMS_FILE="Immich-Go-GUI-${{ env.VERSION }}-${{ matrix.name }}-SHA256SUMS.txt"
           : > "$SUMS_FILE"
           for f in Immich-Go-GUI-${{ env.VERSION }}-*; do
-            if [ -f "$f" ]; then
+            if [ -f "$f" ] && [ "$f" != "$SUMS_FILE" ]; then
               sha256sum "$f" >> "$SUMS_FILE"
             fi
           done
@@ -213,7 +216,8 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         shell: bash
         run: |
-          gh release upload "${{ github.ref_name }}" Immich-Go-GUI-${{ env.VERSION }}-* --clobber
+          gh release upload "${{ github.ref_name }}" Immich-Go-GUI-${{ env.VERSION }}-* --clobber 2>/dev/null || \
+          gh release create "${{ github.ref_name }}" Immich-Go-GUI-${{ env.VERSION }}-* --title "${{ github.ref_name }}" --clobber
 
       - name: Publish assets to Test Pre-Release
         if: ${{ !startsWith(github.ref, 'refs/tags/') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -221,5 +221,5 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         shell: bash
         run: |
-          gh release upload "test-${{ env.VERSION }}" Immich-Go-GUI-${{ env.VERSION }}-* --clobber || \
+          gh release upload "test-${{ env.VERSION }}" Immich-Go-GUI-${{ env.VERSION }}-* --clobber 2>/dev/null || \
           gh release create "test-${{ env.VERSION }}" Immich-Go-GUI-${{ env.VERSION }}-* --title "Test Build test-${{ env.VERSION }}" --target "${{ github.sha }}" --prerelease

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
 
@@ -51,8 +51,6 @@ jobs:
       contents: write
     outputs:
       version: ${{ steps.set-version.outputs.version }}
-    env:
-      VERSION: '1.0.0'
     strategy:
       fail-fast: false
       matrix:
@@ -66,7 +64,7 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
 
@@ -129,7 +127,7 @@ jobs:
         if: matrix.name == 'windows'
         shell: bash
         run: |
-          NUMERIC_VERSION=$(echo "${{ env.VERSION }}" | grep -oE '^[0-9]+\.[0-9]+\.[0-9]+' || echo "1.0.0")
+          NUMERIC_VERSION=$(echo "$VERSION" | grep -oE '^[0-9]+\.[0-9]+\.[0-9]+' || echo "1.0.0")
           uv run python -m nuitka --output-filename=Immich-Go-GUI.exe \
             --file-version="${NUMERIC_VERSION}.0" --product-version="${NUMERIC_VERSION}.0" app.py
 
@@ -138,7 +136,7 @@ jobs:
         run: |
           if (Test-Path "app.dist/app.exe") { Rename-Item -Path "app.dist/app.exe" -NewName "Immich-Go-GUI.exe" }
           Set-Content -Path "app.dist/README.txt" -Value "To launch the application, simply double-click the file named Immich-Go-GUI.exe. You do not need to install anything else."
-          Compress-Archive -Path "app.dist/*" -DestinationPath "Immich-Go-GUI-${{ env.VERSION }}-Windows-x86_64-Portable.zip"
+          Compress-Archive -Path "app.dist/*" -DestinationPath "Immich-Go-GUI-$env:VERSION-Windows-x86_64-Portable.zip"
 
       - name: Compile Windows Installer
         if: matrix.name == 'windows'
@@ -147,7 +145,7 @@ jobs:
           if (-not (Test-Path "C:\Program Files (x86)\Inno Setup 6\ISCC.exe")) {
             choco install innosetup -y
           }
-          & "C:\Program Files (x86)\Inno Setup 6\ISCC.exe" /DMyAppVersion="${{ env.VERSION }}" /DMyOutputFilename="Immich-Go-GUI-${{ env.VERSION }}-Windows-x86_64-Setup" packaging/windows/installer.iss
+          & "C:\Program Files (x86)\Inno Setup 6\ISCC.exe" /DMyAppVersion="$env:VERSION" /DMyOutputFilename="Immich-Go-GUI-$env:VERSION-Windows-x86_64-Setup" packaging/windows/installer.iss
           if (Test-Path "..\..\Immich-Go-GUI-*.exe") {
             Move-Item -Path "..\..\Immich-Go-GUI-*.exe" -Destination "." -Force
           }
@@ -167,7 +165,7 @@ jobs:
           uv run python -m nuitka --output-filename=Immich-Go-GUI app.py
           npm install -g create-dmg@${{ env.CREATE_DMG_VERSION }}
           create-dmg --no-code-sign app.app
-          mv *.dmg "Immich-Go-GUI-${{ env.VERSION }}-${{ steps.macos-arch.outputs.suffix }}.dmg"
+          mv *.dmg "Immich-Go-GUI-$VERSION-${{ steps.macos-arch.outputs.suffix }}.dmg"
 
       - name: Build Linux Standalone
         if: matrix.name == 'linux'
@@ -180,7 +178,7 @@ jobs:
           if [ -f app.dist/app.bin ]; then mv app.dist/app.bin app.dist/Immich-Go-GUI; fi
           if [ -f app.dist/app ]; then mv app.dist/app app.dist/Immich-Go-GUI; fi
           echo "To launch the application, double-click the file named Immich-Go-GUI, or run ./Immich-Go-GUI in the terminal. You do not need to install anything else." > app.dist/README.txt
-          tar -czvf "Immich-Go-GUI-${{ env.VERSION }}-Linux-x86_64-Portable.tar.gz" -C app.dist .
+          tar -czvf "Immich-Go-GUI-$VERSION-Linux-x86_64-Portable.tar.gz" -C app.dist .
 
       - name: Build Linux AppImage
         if: matrix.name == 'linux'
@@ -208,7 +206,7 @@ jobs:
 
           wget -q "https://github.com/AppImage/appimagetool/releases/download/${{ env.APPIMAGETOOL_VERSION }}/appimagetool-x86_64.AppImage" -O appimagetool
           chmod +x appimagetool
-          ./appimagetool --appimage-extract-and-run AppDir "Immich-Go-GUI-${{ env.VERSION }}-Linux-x86_64.AppImage"
+          ./appimagetool --appimage-extract-and-run AppDir "Immich-Go-GUI-$VERSION-Linux-x86_64.AppImage"
 
       - name: Install nFPM
         if: matrix.name == 'linux'
@@ -220,15 +218,15 @@ jobs:
         if: matrix.name == 'linux'
         run: |
           cd packaging/linux
-          nfpm pkg --packager deb --target "../../Immich-Go-GUI-${{ env.VERSION }}-Linux-x86_64.deb"
-          nfpm pkg --packager rpm --target "../../Immich-Go-GUI-${{ env.VERSION }}-Linux-x86_64.rpm"
+          nfpm pkg --packager deb --target "../../Immich-Go-GUI-$VERSION-Linux-x86_64.deb"
+          nfpm pkg --packager rpm --target "../../Immich-Go-GUI-$VERSION-Linux-x86_64.rpm"
 
       - name: Generate SHA256 checksums
         shell: bash
         run: |
-          SUMS_FILE="Immich-Go-GUI-${{ env.VERSION }}-${{ matrix.name }}-SHA256SUMS.txt"
+          SUMS_FILE="Immich-Go-GUI-$VERSION-${{ matrix.name }}-SHA256SUMS.txt"
           : > "$SUMS_FILE"
-          for f in Immich-Go-GUI-${{ env.VERSION }}-*; do
+          for f in Immich-Go-GUI-$VERSION-*; do
             if [ -f "$f" ] && [ "$f" != "$SUMS_FILE" ]; then
               sha256sum "$f" >> "$SUMS_FILE"
             fi
@@ -244,17 +242,17 @@ jobs:
           RELEASE_TAG: ${{ github.ref_name }}
         shell: bash
         run: |
-          gh release upload "$RELEASE_TAG" Immich-Go-GUI-${{ env.VERSION }}-* --clobber 2>/dev/null || \
-          (gh release create "$RELEASE_TAG" Immich-Go-GUI-${{ env.VERSION }}-* --title "$RELEASE_TAG" 2>/dev/null || true; \
-           gh release upload "$RELEASE_TAG" Immich-Go-GUI-${{ env.VERSION }}-* --clobber)
+          gh release upload "$RELEASE_TAG" Immich-Go-GUI-$VERSION-* --clobber 2>/dev/null || \
+          (gh release create "$RELEASE_TAG" Immich-Go-GUI-$VERSION-* --title "$RELEASE_TAG" 2>/dev/null || true; \
+           gh release upload "$RELEASE_TAG" Immich-Go-GUI-$VERSION-* --clobber)
 
       - name: Publish assets to Test Pre-Release
         if: ${{ !startsWith(github.ref, 'refs/tags/') }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RELEASE_TAG: test-${{ env.VERSION }}
+          RELEASE_TAG: test-${{ steps.set-version.outputs.version }}
         shell: bash
         run: |
-          gh release upload "$RELEASE_TAG" Immich-Go-GUI-${{ env.VERSION }}-* --clobber 2>/dev/null || \
-          (gh release create "$RELEASE_TAG" Immich-Go-GUI-${{ env.VERSION }}-* --title "Test Build $RELEASE_TAG" --target "${{ github.sha }}" --prerelease 2>/dev/null || true; \
-           gh release upload "$RELEASE_TAG" Immich-Go-GUI-${{ env.VERSION }}-* --clobber)
+          gh release upload "$RELEASE_TAG" Immich-Go-GUI-$VERSION-* --clobber 2>/dev/null || \
+          (gh release create "$RELEASE_TAG" Immich-Go-GUI-$VERSION-* --title "Test Build $RELEASE_TAG" --target "${{ github.sha }}" --prerelease 2>/dev/null || true; \
+           gh release upload "$RELEASE_TAG" Immich-Go-GUI-$VERSION-* --clobber)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,7 +103,7 @@ jobs:
           path: |
             ~/.cache/Nuitka
             ~/Library/Caches/Nuitka
-            ${{ env.LOCALAPPDATA }}\Nuitka\Nuitka
+            ~/AppData/Local/Nuitka/Nuitka
           key: ${{ runner.os }}-nuitka-${{ matrix.name }}-${{ hashFiles('pyproject.toml', 'app.py', 'core/**') }}
           restore-keys: |
             ${{ runner.os }}-nuitka-${{ matrix.name }}-

--- a/packaging/linux/immich-go-gui.appdata.xml
+++ b/packaging/linux/immich-go-gui.appdata.xml
@@ -8,5 +8,6 @@
   <description>
     <p>Desktop GUI application for immich-go to easily upload Google Photos, Apple Photos, and media archives to Immich.</p>
   </description>
-  <homepage>https://github.com/shitan198u/immich-go-gui</homepage>
+  <launchable type="desktop-id">immich-go-gui.desktop</launchable>
+  <url type="homepage">https://github.com/shitan198u/immich-go-gui</url>
 </component>

--- a/packaging/linux/immich-go-gui.appdata.xml
+++ b/packaging/linux/immich-go-gui.appdata.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>immich-go-gui</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>MIT</project_license>
+  <name>Immich-Go GUI</name>
+  <summary>Desktop GUI for immich-go bulk media operations</summary>
+  <description>
+    <p>Desktop GUI application for immich-go to easily upload Google Photos, Apple Photos, and media archives to Immich.</p>
+  </description>
+  <homepage>https://github.com/shitan198u/immich-go-gui</homepage>
+</component>

--- a/packaging/linux/nfpm.yaml
+++ b/packaging/linux/nfpm.yaml
@@ -4,6 +4,7 @@ platform: "linux"
 version: "${VERSION:-1.0.0}"
 description: "GUI for Immich-Go"
 homepage: "https://github.com/shitan198u/immich-go-gui"
+maintainer: "shitan198u <shitan198u@users.noreply.github.com>"
 license: "MIT"
 contents:
   - src: ../../app.dist/


### PR DESCRIPTION
## Summary
Fixes the release asset upload failure on `master` ([run 31711054911 / job 94484258093](https://github.com/shitan198u/immich-go-gui/actions/runs/31711054911/job/94484258093)).

## Root Cause
1. **API Race Condition**: Concurrent matrix build runner jobs (Linux, Windows, macOS) simultaneously called `softprops/action-gh-release@v3` to mutate/create release metadata for tag `v1.4.0`, causing GitHub API contention and `HttpError` failures.
2. **Hardcoded Platform Paths**: `softprops/action-gh-release` threw unmatched file warnings on missing platform binaries (e.g. Windows `.exe` paths on Linux runner).

## Solution
Replaced `softprops/action-gh-release@v3` with GitHub's native `gh release upload <tag> Immich-Go-GUI-${{ env.VERSION }}-* --clobber` CLI tool:
- Directly uploads matching platform assets built on the current runner without mutating release metadata concurrently.
- Uses `--clobber` to safely overwrite/update assets if re-run.

## Verification
- `uv run python scripts/sync_version.py --check`: **PASSED** (v1.4.0)
- `uv run python scripts/sync_test_count.py --check`: **PASSED**
- `uv run ty check core/`: **PASSED**
- `uv run python app.py --self-test`: **PASSED**
- `uv run pre-commit run --all-files`: **PASSED**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Release Improvements**
  * Release builds now publish platform-specific assets more reliably.
  * Updated assets can replace existing release files without creating duplicates.
  * Test builds are available through clearly identified prereleases when no matching release exists.
  * Test prereleases target the commit used to generate them, improving build traceability.
  * Release publishing is more consistent across tagged and test builds.
* **Linux Packaging**
  * Added desktop application metadata for improved Linux software-center integration.
  * Included maintainer information in the Linux package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->