### PR TITLE
chore(repo): retire staging branch and streamline PR workflow to master

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -31,11 +31,10 @@ Authoritative context for AI agents working in this repository. When user-provid
 
 | Branch | Purpose |
 |--------|---------|
-| `master` | Production; Release Please merges only |
-| `staging` | Active integration |
-| Feature/fix branches | Target `staging` via PR |
+| `master` | Main integration & production; PR target |
+| Feature/fix branches | Target `master` via PR |
 
-**Squash merges required** when merging `staging` → `master` so Release Please commit scanning stays clean.
+**Squash merges or Conventional Commits required** when merging PRs → `master` so Release Please commit scanning stays clean.
 
 ---
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,9 +3,7 @@ name: "CodeQL"
 on:
   push:
     branches: [ "master" ]
-  # NOTE: No `branches:` filter on pull_request — CI must run on PRs targeting
-  # ANY base branch. Filtering to `branches: [master]` only caused PRs opened
-  # against staging to silently get zero CI checks.
+  # NOTE: No `branches:` filter on pull_request — CI runs on all pull requests.
   pull_request:
   schedule:
     - cron: '30 1 * * 0' # Run every Sunday at 1:30 AM

--- a/.github/workflows/manual-prerelease.yml
+++ b/.github/workflows/manual-prerelease.yml
@@ -10,10 +10,9 @@ on:
       branch:
         description: "Branch to create prerelease from"
         required: true
-        default: "staging"
+        default: "master"
         type: choice
         options:
-          - staging
           - master
       version_type:
         description: "Version increment type"

--- a/.github/workflows/pr-fast-feedback.yml
+++ b/.github/workflows/pr-fast-feedback.yml
@@ -5,9 +5,7 @@ name: PR Fast Feedback
 # Nuitka build verification, and posts automated PR feedback.
 
 on:
-  # NOTE: No `branches:` filter here — CI must run on PRs targeting ANY base
-  # branch (master, staging, etc.). Filtering to `branches: [master]` only
-  # caused PRs opened against staging to silently get zero CI checks.
+  # NOTE: No `branches:` filter here — CI runs on all pull requests.
   pull_request:
   workflow_dispatch:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Thank you for helping improve Immich-Go GUI. Clear PRs and docs keep the project healthy for users and maintainers alike.
 
-> When browsing on GitHub at the repository root, open [docs/CONTRIBUTING.md](https://github.com/shitan198u/immich-go-gui/blob/staging/docs/CONTRIBUTING.md) (or the [published docs](https://shitan198u.github.io/immich-go-gui/CONTRIBUTING/)) so internal doc links resolve correctly.
+> When browsing on GitHub at the repository root, open [docs/CONTRIBUTING.md](https://github.com/shitan198u/immich-go-gui/blob/master/docs/CONTRIBUTING.md) (or the [published docs](https://shitan198u.github.io/immich-go-gui/CONTRIBUTING/)) so internal doc links resolve correctly.
 
 ## Where do I go from here?
 
@@ -81,9 +81,9 @@ Details: [Testing guide](developer-guide/testing.md).
 
 ## Making a pull request
 
-1. Branch from **`staging`**: `git checkout -b feature-or-bugfix-name`
+1. Branch from **`master`**: `git checkout -b feature-or-bugfix-name`
 2. Make focused commits (see commit style below)
-3. Push and open a PR **targeting `staging`**
+3. Push and open a PR **targeting `master`**
 4. Fill out the PR template (platforms tested, docs updated, tests run)
 
 ### Commit message style
@@ -111,10 +111,10 @@ docs: document admin API key and job pausing
 
 | Branch | Role |
 |--------|------|
-| `staging` | Active development; **all contributor PRs land here** |
-| `master` | Production; advanced by Release Please after squash merge from `staging` |
+| `master` | Main integration & production; all contributor PRs target `master` |
+| Feature/fix branches | Created from `master` and merged via PR |
 
-Do not open routine feature PRs directly against `master`.
+Feature branches are merged into `master` using Conventional Commits so Release Please automates versioning and changelog updates.
 
 ## Design rules worth knowing early
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,7 +81,7 @@ Details: [Testing guide](developer-guide/testing.md).
 
 ## Making a pull request
 
-1. Branch from **`master`**: `git checkout -b feature-or-bugfix-name`
+1. Branch from **`master`**: `git checkout -b feature-or-bugfix-name master`
 2. Make focused commits (see commit style below)
 3. Push and open a PR **targeting `master`**
 4. Fill out the PR template (platforms tested, docs updated, tests run)

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Contributions are welcome. Please:
 
 1. Read [CONTRIBUTING.md](CONTRIBUTING.md)
 2. Skim the [Developer Guide](docs/developer-guide/architecture.md)
-3. Open PRs against **`staging`** (not `master`)
+3. Open PRs against **`master`**
 4. Prefer [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `docs:`, …) so Release Please can version cleanly
 
 ```bash

--- a/docs/user-guide/faq.md
+++ b/docs/user-guide/faq.md
@@ -131,7 +131,7 @@ Per profile, in `monitor_config.json` (settings) and `monitor_state.json` (last-
 
 ### Where should pull requests target?
 
-Always open PRs against **`staging`**, not `master`. See [CONTRIBUTING](../CONTRIBUTING.md).
+Always open PRs against **`master`**. See [CONTRIBUTING](../CONTRIBUTING.md).
 
 ### How do I run tests?
 

--- a/docs/user-guide/glossary.md
+++ b/docs/user-guide/glossary.md
@@ -31,7 +31,7 @@ Terms used throughout Immich-Go GUI documentation and the immich-go ecosystem.
 | **Process lock** | File under `{config_dir}/locks/` preventing concurrent GUI-launched jobs. |
 | **Nuitka** | Python compiler used to produce standalone release binaries. |
 | **Release Please** | Automation that versions the project and updates `CHANGELOG.md` from conventional commits. |
-| **staging / master** | Development vs production branches; PRs target `staging`. |
+| **master** | Main repository branch; contributor PRs target `master`. |
 | **SHA256 verification** | Checksum validation when downloading immich-go releases. |
 | **Skip SSL verification** | Disables TLS certificate validation — lab/self-signed only. |
 | **Monitor** | Background subsystem that watches local folders and uploads new media to Immich automatically. |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,8 +4,8 @@ site_author: shitan198u
 site_url: https://shitan198u.github.io/immich-go-gui/
 repo_url: https://github.com/shitan198u/immich-go-gui
 repo_name: shitan198u/immich-go-gui
-# Point edit links at staging (active development branch for docs edits).
-edit_uri: edit/staging/docs/
+# Point edit links at master (active development branch for docs edits).
+edit_uri: edit/master/docs/
 
 # absolute_links: warn under --strict fails the build on absolute self-links.
 # Prefer relative paths within the docs tree; keep absolute only for external URLs.


### PR DESCRIPTION
## Summary

Streamlines the contribution and release model by retiring the `staging` branch convention. All contributor pull requests and feature branches now directly target `master`.

---

## Key Changes

1. **Documentation Site & Contribution Guides**:
   - **`mkdocs.yml`**: Updated `edit_uri` from `edit/staging/docs/` to `edit/master/docs/`.
   - **`CONTRIBUTING.md`**: Updated branching guide to branch from and open PRs targeting `master`. Updated blob link reference.
   - **`README.md`**: Updated contribution instructions to open PRs against `master`.
   - **`docs/user-guide/faq.md`**: Updated PR target FAQ answer to `master`.
   - **`docs/user-guide/glossary.md`**: Simplified glossary entry from `staging / master` to `master`.

2. **Agent Guidelines & Workflows**:
   - **`.agents/AGENTS.md`**: Updated Git Branching table to define `master` as the primary integration and PR target.
   - **`.github/workflows/manual-prerelease.yml`**: Changed default branch option from `staging` to `master` and removed `staging` from the branch selector.
   - **`.github/workflows/pr-fast-feedback.yml` & `.github/workflows/codeql.yml`**: Cleaned up workflow comments.

---

## Verification

- ✅ `uv run pre-commit run --all-files` (All passed)
- ✅ `uv run ty check core/` (All checks passed)
- ✅ `uv run python app.py --self-test` (`self-test: ok`)
- ✅ `uv run python scripts/sync_version.py --check` (Passed)
- ✅ `uv run mkdocs build` (Site built successfully in 1.06s)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated contribution, branching, pull-request, FAQ, glossary, and edit-link guidance to use `master` as the primary branch.
  * Clarified that pull requests should target `master` and follow squash-merge or Conventional Commit practices.
  * Corrected repository documentation links to reference the current primary branch.

* **Chores**
  * Updated prerelease workflow defaults to `master`.
  * Clarified that pull-request checks run for all pull requests without branch restrictions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->