### PR TITLE
fix: preserve directory structure in Linux deb and rpm packages

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -115,7 +115,7 @@ Nuitka directives live at the top of `app.py`. All release workflow invocations 
 
 ## 6. Testing
 
-- **Suite Metrics**: **457 tests across 28 modules**, coverage gate **75%** on `core` (Linux CI).
+- **Suite Metrics**: **462 tests across 29 modules**, coverage gate **75%** on `core` (Linux CI).
 - **Conventions**:
   - Windows path normalization: pass argv through `_norm_argv(...)` before comparing paths.
   - Golden fixtures: `tests/fixtures/command_states/*.json`

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -180,6 +180,11 @@ jobs:
           echo "To launch the application, double-click the file named Immich-Go-GUI, or run ./Immich-Go-GUI in the terminal. You do not need to install anything else." > app.dist/README.txt
           tar -czvf "Immich-Go-GUI-$VERSION-Linux-x86_64-Portable.tar.gz" -C app.dist .
 
+      - name: Smoke test Linux standalone binary
+        if: matrix.name == 'linux'
+        run: |
+          QT_QPA_PLATFORM=offscreen xvfb-run app.dist/Immich-Go-GUI --self-test
+
       - name: Build Linux AppImage
         if: matrix.name == 'linux'
         run: |
@@ -220,6 +225,17 @@ jobs:
           cd packaging/linux
           nfpm pkg --packager deb --target "../../Immich-Go-GUI-$VERSION-Linux-x86_64.deb"
           nfpm pkg --packager rpm --target "../../Immich-Go-GUI-$VERSION-Linux-x86_64.rpm"
+
+      - name: Verify Linux package structure
+        if: matrix.name == 'linux'
+        run: |
+          DEB_FILE="Immich-Go-GUI-$VERSION-Linux-x86_64.deb"
+          echo "Verifying $DEB_FILE directory structure..."
+          dpkg-deb -c "$DEB_FILE" | grep -E 'opt/immich-go-gui/shiboken6/Shiboken' || { echo "ERROR: DEB package is missing shiboken6/ subdirectory (directory flattening regression)"; exit 1; }
+          dpkg-deb -c "$DEB_FILE" | grep -E 'opt/immich-go-gui/PySide6/QtCore' || { echo "ERROR: DEB package is missing PySide6/ subdirectory (directory flattening regression)"; exit 1; }
+          dpkg-deb -c "$DEB_FILE" | grep -E 'opt/immich-go-gui/core/flags.toml' || { echo "ERROR: DEB package is missing core/flags.toml"; exit 1; }
+          dpkg-deb -c "$DEB_FILE" | grep -E 'opt/immich-go-gui/assets/icons/' || { echo "ERROR: DEB package is missing assets/icons/"; exit 1; }
+          echo "DEB package structure successfully verified."
 
       - name: Generate SHA256 checksums
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,7 +95,7 @@ jobs:
         if: matrix.name == 'linux'
         run: |
           sudo apt-get update
-          sudo apt-get install -y libxkbcommon-x11-0 libxcb-cursor0 xvfb libegl1 libgl1 libxcb-xinerama0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-render-util0 libxcb-shape0
+          sudo apt-get install -y libxkbcommon-x11-0 libxcb-cursor0 xvfb libegl1 libgl1 libxcb-xinerama0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-render-util0 libxcb-shape0 rpm
 
       - name: Setup Ccache
         uses: hendrikmuhs/ccache-action@d62db5f07c26379fc4b4e0916f098a92573c3b03 # v1.2.23
@@ -236,12 +236,20 @@ jobs:
         if: matrix.name == 'linux'
         run: |
           DEB_FILE="Immich-Go-GUI-$VERSION-Linux-x86_64.deb"
+          RPM_FILE="Immich-Go-GUI-$VERSION-Linux-x86_64.rpm"
           echo "Verifying $DEB_FILE directory structure..."
           dpkg-deb -c "$DEB_FILE" | grep -E 'opt/immich-go-gui/shiboken6/Shiboken' || { echo "ERROR: DEB package is missing shiboken6/ subdirectory (directory flattening regression)"; exit 1; }
           dpkg-deb -c "$DEB_FILE" | grep -E 'opt/immich-go-gui/PySide6/QtCore' || { echo "ERROR: DEB package is missing PySide6/ subdirectory (directory flattening regression)"; exit 1; }
           dpkg-deb -c "$DEB_FILE" | grep -E 'opt/immich-go-gui/core/flags.toml' || { echo "ERROR: DEB package is missing core/flags.toml"; exit 1; }
           dpkg-deb -c "$DEB_FILE" | grep -E 'opt/immich-go-gui/assets/icons/' || { echo "ERROR: DEB package is missing assets/icons/"; exit 1; }
           echo "DEB package structure successfully verified."
+
+          echo "Verifying $RPM_FILE directory structure..."
+          rpm -qlp "$RPM_FILE" | grep -E 'opt/immich-go-gui/shiboken6/Shiboken' || { echo "ERROR: RPM package is missing shiboken6/ subdirectory (directory flattening regression)"; exit 1; }
+          rpm -qlp "$RPM_FILE" | grep -E 'opt/immich-go-gui/PySide6/QtCore' || { echo "ERROR: RPM package is missing PySide6/ subdirectory (directory flattening regression)"; exit 1; }
+          rpm -qlp "$RPM_FILE" | grep -E 'opt/immich-go-gui/core/flags.toml' || { echo "ERROR: RPM package is missing core/flags.toml"; exit 1; }
+          rpm -qlp "$RPM_FILE" | grep -E 'opt/immich-go-gui/assets/icons/' || { echo "ERROR: RPM package is missing assets/icons/"; exit 1; }
+          echo "RPM package structure successfully verified."
 
       - name: Generate SHA256 checksums
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,6 +91,12 @@ jobs:
       - name: Install dependencies
         run: uv sync --dev
 
+      - name: Install Linux Desktop Dependencies
+        if: matrix.name == 'linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libxkbcommon-x11-0 libxcb-cursor0 xvfb libegl1 libgl1 libxcb-xinerama0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-render-util0 libxcb-shape0
+
       - name: Setup Ccache
         uses: hendrikmuhs/ccache-action@d62db5f07c26379fc4b4e0916f098a92573c3b03 # v1.2.23
         with:

--- a/docs/developer-guide/architecture.md
+++ b/docs/developer-guide/architecture.md
@@ -116,7 +116,7 @@ immich-go-gui/
 │   ├── activity_monitor.py# Activity-based auto-pause detection
 │   ├── network_awareness.py # Metered/SSID/offline detection & policy
 │   └── __init__.py        # Public re-exports
-├── tests/                 # Focused Pytest modules (28 modules, ~457 tests)
+├── tests/                 # Focused Pytest modules (29 modules, ~462 tests)
 ├── scripts/               # CLI help capture, review bundles, icon generator
 ├── docs/                  # User + developer + reference docs
 ├── packaging/             # Linux nfpm + Windows Inno Setup

--- a/docs/developer-guide/testing.md
+++ b/docs/developer-guide/testing.md
@@ -1,6 +1,6 @@
 # Testing
 
-The test suite lives in `tests/` (457 tests across 28 modules) using `pytest` and `pytest-qt`.
+The test suite lives in `tests/` (462 tests across 29 modules) using `pytest` and `pytest-qt`.
 
 ## Running Tests
 

--- a/packaging/linux/nfpm.yaml
+++ b/packaging/linux/nfpm.yaml
@@ -7,8 +7,8 @@ homepage: "https://github.com/shitan198u/immich-go-gui"
 maintainer: "shitan198u <shitan198u@users.noreply.github.com>"
 license: "MIT"
 contents:
-  - src: ../../app.dist/
-    dst: /opt/immich-go-gui/
+  - src: ../../app.dist
+    dst: /opt/immich-go-gui
   - src: ../../immich-go-gui.png
     dst: /usr/share/pixmaps/immich-go-gui.png
   - src: ./immich-go-gui.desktop

--- a/scripts/sync_test_count.py
+++ b/scripts/sync_test_count.py
@@ -104,8 +104,8 @@ def main() -> int:
         ),
         (
             ROOT_DIR / "docs" / "developer-guide" / "architecture.md",
-            r"~\d+\s+tests",
-            f"~{test_count} tests",
+            r"(?:\d+\s+modules,\s+)?~\d+\s+tests",
+            f"{module_count} modules, ~{test_count} tests",
         ),
     ]
 

--- a/scripts/sync_test_count.py
+++ b/scripts/sync_test_count.py
@@ -107,6 +107,11 @@ def main() -> int:
             r"(?:\d+\s+modules,\s+)?~\d+\s+tests",
             f"{module_count} modules, ~{test_count} tests",
         ),
+        (
+            ROOT_DIR / ".agents" / "AGENTS.md",
+            r"\*\*Suite Metrics\*\*:\s+\*\*\d+\s+tests\s+across\s+\d+\s+modules\*\*",
+            f"**Suite Metrics**: **{test_count} tests across {module_count} modules**",
+        ),
     ]
 
     all_ok = True

--- a/tests/test_packaging_guardrails.py
+++ b/tests/test_packaging_guardrails.py
@@ -1,0 +1,126 @@
+"""Packaging guardrails: enforce packaging configuration invariants to prevent
+subpackage flattening, missing assets, and broken installer scripts.
+
+These tests are intentionally Qt-free and pure-Python so they run fast in CI
+and catch packaging regressions early.
+"""
+
+import re
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PACKAGING_ROOT = REPO_ROOT / "packaging"
+LINUX_PKG_ROOT = PACKAGING_ROOT / "linux"
+WINDOWS_PKG_ROOT = PACKAGING_ROOT / "windows"
+
+
+def test_nfpm_yaml_no_trailing_slash_on_directory_destinations():
+    """nfpm 2.47.0+ flattens directory copies if dst ends with a trailing slash.
+
+    This test enforces that directory mappings in packaging/linux/nfpm.yaml do
+    not end with a trailing slash, preventing Qt and Shiboken shared object
+    flattening.
+    """
+    nfpm_path = LINUX_PKG_ROOT / "nfpm.yaml"
+    assert nfpm_path.is_file(), f"Missing {nfpm_path}"
+
+    content = nfpm_path.read_text(encoding="utf-8")
+    lines = content.splitlines()
+
+    in_contents = False
+    current_entry = {}
+    entries = []
+
+    for line in lines:
+        stripped = line.strip()
+        if stripped.startswith("contents:"):
+            in_contents = True
+            continue
+        if in_contents:
+            if stripped.startswith("- src:"):
+                if current_entry:
+                    entries.append(current_entry)
+                current_entry = {"src": stripped.split(":", 1)[1].strip()}
+            elif stripped.startswith("dst:") and current_entry:
+                current_entry["dst"] = stripped.split(":", 1)[1].strip()
+            elif (
+                stripped and not stripped.startswith("#") and not line.startswith("  ")
+            ):
+                # End of contents block
+                in_contents = False
+
+    if current_entry:
+        entries.append(current_entry)
+
+    assert entries, "No entries parsed from nfpm.yaml contents block"
+
+    for entry in entries:
+        src = entry.get("src", "")
+        dst = entry.get("dst", "")
+
+        # Target destinations must not end with a trailing slash
+        assert not dst.endswith("/"), (
+            f"nfpm destination '{dst}' must not end with a trailing slash '/' "
+            f"(causes silent directory flattening in nfpm for src '{src}')"
+        )
+        assert dst.startswith("/"), f"nfpm destination '{dst}' must be an absolute path"
+
+
+def test_nfpm_referenced_static_files_exist():
+    """Verify that static files referenced in nfpm.yaml actually exist in the repo."""
+    nfpm_path = LINUX_PKG_ROOT / "nfpm.yaml"
+    content = nfpm_path.read_text(encoding="utf-8")
+
+    # Match static files (exclude app.dist which is generated at build time)
+    for match in re.finditer(r"src:\s*(\S+)", content):
+        src_path_str = match.group(1)
+        if "app.dist" in src_path_str:
+            continue
+        # Resolve relative to packaging/linux/
+        resolved = (LINUX_PKG_ROOT / src_path_str).resolve()
+        assert resolved.exists(), (
+            f"File referenced in nfpm.yaml does not exist: {src_path_str} -> {resolved}"
+        )
+
+
+def test_linux_desktop_file_validity():
+    """Verify packaging/linux/immich-go-gui.desktop contains required Desktop Entry keys."""
+    desktop_path = LINUX_PKG_ROOT / "immich-go-gui.desktop"
+    assert desktop_path.is_file(), f"Missing {desktop_path}"
+
+    content = desktop_path.read_text(encoding="utf-8")
+    assert "[Desktop Entry]" in content
+    assert re.search(r"^Name\s*=\s*.+$", content, re.MULTILINE)
+    assert re.search(r"^Exec\s*=\s*.+$", content, re.MULTILINE)
+    assert re.search(r"^Icon\s*=\s*.+$", content, re.MULTILINE)
+    assert re.search(r"^Type\s*=\s*Application$", content, re.MULTILINE)
+
+
+def test_linux_appdata_xml_validity():
+    """Verify packaging/linux/immich-go-gui.appdata.xml is well-formed XML with valid ID."""
+    appdata_path = LINUX_PKG_ROOT / "immich-go-gui.appdata.xml"
+    assert appdata_path.is_file(), f"Missing {appdata_path}"
+
+    tree = ET.parse(appdata_path)
+    root = tree.getroot()
+    assert root.tag == "component"
+    id_elem = root.find("id")
+    assert id_elem is not None and id_elem.text, "Missing or empty <id> in appdata.xml"
+
+
+def test_windows_installer_iss_preserves_subdirectories():
+    """Verify Inno Setup script includes flags to recurse subdirectories."""
+    iss_path = WINDOWS_PKG_ROOT / "installer.iss"
+    assert iss_path.is_file(), f"Missing {iss_path}"
+
+    content = iss_path.read_text(encoding="utf-8")
+    match = re.search(
+        r'Source:\s*"app\.dist\\?\*".*Flags:\s*(.*)', content, re.IGNORECASE
+    )
+    assert match, "Source directive for app.dist not found in installer.iss"
+    flags = match.group(1).lower()
+    assert "recursesubdirs" in flags, "Inno Setup must include 'recursesubdirs' flag"
+    assert "createallsubdirs" in flags, (
+        "Inno Setup must include 'createallsubdirs' flag"
+    )

--- a/tests/test_packaging_guardrails.py
+++ b/tests/test_packaging_guardrails.py
@@ -102,6 +102,7 @@ def test_linux_appdata_xml_validity():
     appdata_path = LINUX_PKG_ROOT / "immich-go-gui.appdata.xml"
     assert appdata_path.is_file(), f"Missing {appdata_path}"
 
+    # Static repository-controlled AppStream metadata file
     tree = ET.parse(appdata_path)
     root = tree.getroot()
     assert root.tag == "component"

--- a/uv.lock
+++ b/uv.lock
@@ -299,7 +299,7 @@ wheels = [
 
 [[package]]
 name = "immich-go-gui"
-version = "1.4.0"
+version = "1.4.1"
 source = { virtual = "." }
 dependencies = [
     { name = "idna" },


### PR DESCRIPTION
## Summary
Fixes an issue where installed Linux `.deb` and `.rpm` packages failed to launch due to missing package subdirectories (`shiboken6/`, `PySide6/`, `assets/`, `core/`).

### Root Cause
In `packaging/linux/nfpm.yaml`, the directory destination was configured with a trailing slash (`dst: /opt/immich-go-gui/`). In `nfpm` 2.47.0+, directory copies where `dst` ends with `/` flatten the entire directory tree into `/opt/immich-go-gui/<basename>`. Consequently, runtime dependencies like `shiboken6/Shiboken.so` and `PySide6/QtCore.so` were placed at top-level `/opt/immich-go-gui/Shiboken.so` rather than within their package subdirectories, triggering `ImportError: /opt/immich-go-gui/shiboken6/Shiboken.so: cannot open shared object file`.

### Changes Made
1. **Packaging Fix (`packaging/linux/nfpm.yaml`)**:
   - Removed trailing slashes from directory mappings (`src: ../../app.dist` and `dst: /opt/immich-go-gui`) so `nfpm` preserves relative subdirectory structures.
2. **Release Workflow Hardening (`.github/workflows/release.yml`)**:
   - Added a standalone binary smoke test (`app.dist/Immich-Go-GUI --self-test`) right after Linux Nuitka compilation to verify binary executable integrity.
   - Added a DEB package structure verification step that inspects the built `.deb` with `dpkg-deb -c` to verify that `shiboken6/`, `PySide6/`, `core/flags.toml`, and `assets/icons/` exist in their expected subdirectories.
3. **Packaging Guardrails (`tests/test_packaging_guardrails.py`)**:
   - Added automated tests to verify `nfpm.yaml` destination paths do not end with trailing slashes, static asset references exist, and desktop/installer configuration invariants are satisfied.
4. **Documentation & Metrics Sync**:
   - Synchronized test count metrics (462 tests across 29 modules) across documentation and developer guides.

### Verification
- Built test `.deb` and `.rpm` packages with `nfpm` locally and verified with `dpkg-deb -c` that all subdirectories (`PySide6/`, `shiboken6/`, `core/`, `assets/`) are preserved.
- Verified standalone binary launches and passes self-test (`QT_QPA_PLATFORM=offscreen app.dist/Immich-Go-GUI --self-test`).
- Passed full pre-PR gate (`uv run pre-commit run --all-files`, `uv run ty check core/`, `uv run python app.py --self-test`, `uv run python scripts/sync_version.py --check`, and 462 pytest tests).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Linux package path handling to ensure directories and bundled resources are installed correctly.
  * Added validation for desktop entries, AppData metadata, and Windows installer subdirectories.

* **Quality Improvements**
  * Linux release builds now run a smoke test and verify required packaged files.

* **Documentation**
  * Updated testing metrics to reflect 462 tests across 29 modules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->