### PR TITLE
fix: bake static application version into core.version for standalone builds and packages

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -115,7 +115,7 @@ Nuitka directives live at the top of `app.py`. All release workflow invocations 
 
 ## 6. Testing
 
-- **Suite Metrics**: **462 tests across 29 modules**, coverage gate **75%** on `core` (Linux CI).
+- **Suite Metrics**: **465 tests across 30 modules**, coverage gate **75%** on `core` (Linux CI).
 - **Conventions**:
   - Windows path normalization: pass argv through `_norm_argv(...)` before comparing paths.
   - Golden fixtures: `tests/fixtures/command_states/*.json`

--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -115,7 +115,7 @@ Nuitka directives live at the top of `app.py`. All release workflow invocations 
 
 ## 6. Testing
 
-- **Suite Metrics**: **468 tests across 30 modules**, coverage gate **75%** on `core` (Linux CI).
+- **Suite Metrics**: **469 tests across 30 modules**, coverage gate **75%** on `core` (Linux CI).
 - **Conventions**:
   - Windows path normalization: pass argv through `_norm_argv(...)` before comparing paths.
   - Golden fixtures: `tests/fixtures/command_states/*.json`

--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -115,7 +115,7 @@ Nuitka directives live at the top of `app.py`. All release workflow invocations 
 
 ## 6. Testing
 
-- **Suite Metrics**: **465 tests across 30 modules**, coverage gate **75%** on `core` (Linux CI).
+- **Suite Metrics**: **468 tests across 30 modules**, coverage gate **75%** on `core` (Linux CI).
 - **Conventions**:
   - Windows path normalization: pass argv through `_norm_argv(...)` before comparing paths.
   - Golden fixtures: `tests/fixtures/command_states/*.json`

--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -12,6 +12,10 @@
       "extra-files": [
         {
           "type": "generic",
+          "path": "core/version.py"
+        },
+        {
+          "type": "generic",
           "path": "docs/README.md"
         },
         {

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -144,6 +144,7 @@ from .profile_manager import (
     validate_profile_name,
 )
 from .terminal_launcher import LaunchResult, launch_external_terminal
+from .version import __version__, get_app_version
 
 __all__ = [
     # cli_schema
@@ -206,6 +207,7 @@ __all__ = [
     "ValidationResult",
     "VersionSupport",
     "WatchedFolder",
+    "__version__",
     "active_profile_name",
     "assert_flag_allowed",
     # command_builder
@@ -230,6 +232,7 @@ __all__ = [
     "ensure_default_profile",
     "flag_allowed_for_tab",
     "get_api_key",
+    "get_app_version",
     "get_binary_path",
     "get_config_load_warning",
     "get_secret_with_fallback",

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -144,7 +144,7 @@ from .profile_manager import (
     validate_profile_name,
 )
 from .terminal_launcher import LaunchResult, launch_external_terminal
-from .version import __version__, get_app_version
+from .version import __version__, get_app_version, is_development_build
 
 __all__ = [
     # cli_schema
@@ -239,6 +239,7 @@ __all__ = [
     "get_version_support",
     # cli_help
     "help_name_for_tab",
+    "is_development_build",
     "is_lock_active",
     "launch_external_terminal",
     "list_profiles",

--- a/core/version.py
+++ b/core/version.py
@@ -26,7 +26,7 @@ def is_development_build() -> bool:
     # If running from a directory with a .git repository, it is a developer git checkout
     try:
         repo_root = Path(__file__).resolve().parent.parent
-        if (repo_root / ".git").is_dir():
+        if (repo_root / ".git").exists():
             return True
     except Exception:
         pass

--- a/core/version.py
+++ b/core/version.py
@@ -1,0 +1,21 @@
+"""Application version definitions."""
+
+from __future__ import annotations
+
+from importlib.metadata import version as _pkg_version
+
+__version__ = "1.4.2"
+
+
+def get_app_version() -> str:
+    """Return the application version string.
+
+    Prefers the static code-level `__version__` baked into the distribution,
+    falling back to package metadata and finally 'dev'.
+    """
+    if __version__ and __version__ != "dev":
+        return __version__
+    try:
+        return _pkg_version("immich-go-gui")
+    except Exception:
+        return "dev"

--- a/core/version.py
+++ b/core/version.py
@@ -1,21 +1,54 @@
-"""Application version definitions."""
+"""Application version definitions and environment detection."""
 
 from __future__ import annotations
 
+import os
+import sys
 from importlib.metadata import version as _pkg_version
+from pathlib import Path
 
 __version__ = "1.4.2"
+
+
+def is_development_build() -> bool:
+    """Return True if running directly from a source tree / git clone rather than a compiled binary.
+
+    Compiled standalone releases (Nuitka, PyInstaller, etc.) set `sys.frozen` or
+    `__compiled__` and do not include a `.git` working tree.
+    """
+    if os.environ.get("IMMICH_GO_GUI_DEV") == "1":
+        return True
+    if os.environ.get("IMMICH_GO_GUI_DEV") == "0":
+        return False
+    # If compiled with Nuitka or frozen binary, it is a release/standalone build
+    if hasattr(sys, "__compiled__") or getattr(sys, "frozen", False):
+        return False
+    # If running from a directory with a .git repository, it is a developer git checkout
+    try:
+        repo_root = Path(__file__).resolve().parent.parent
+        if (repo_root / ".git").is_dir():
+            return True
+    except Exception:
+        pass
+    return False
 
 
 def get_app_version() -> str:
     """Return the application version string.
 
-    Prefers the static code-level `__version__` baked into the distribution,
-    falling back to package metadata and finally 'dev'.
+    In release / compiled standalone builds (e.g. .deb, .rpm, AppImage, DMG, EXE),
+    returns the static version string (e.g. '1.4.2').
+    In a git clone / developer source tree, appends the '-dev' suffix (e.g. '1.4.2-dev').
     """
-    if __version__ and __version__ != "dev":
-        return __version__
-    try:
-        return _pkg_version("immich-go-gui")
-    except Exception:
-        return "dev"
+    base_version = __version__
+    if not base_version or base_version == "dev":
+        try:
+            base_version = _pkg_version("immich-go-gui")
+        except Exception:
+            return "dev"
+
+    if is_development_build():
+        return (
+            f"{base_version}-dev" if not base_version.endswith("-dev") else base_version
+        )
+    return base_version

--- a/docs/developer-guide/architecture.md
+++ b/docs/developer-guide/architecture.md
@@ -116,7 +116,7 @@ immich-go-gui/
 │   ├── activity_monitor.py# Activity-based auto-pause detection
 │   ├── network_awareness.py # Metered/SSID/offline detection & policy
 │   └── __init__.py        # Public re-exports
-├── tests/                 # Focused Pytest modules (30 modules, ~465 tests)
+├── tests/                 # Focused Pytest modules (30 modules, ~468 tests)
 ├── scripts/               # CLI help capture, review bundles, icon generator
 ├── docs/                  # User + developer + reference docs
 ├── packaging/             # Linux nfpm + Windows Inno Setup

--- a/docs/developer-guide/architecture.md
+++ b/docs/developer-guide/architecture.md
@@ -116,7 +116,7 @@ immich-go-gui/
 │   ├── activity_monitor.py# Activity-based auto-pause detection
 │   ├── network_awareness.py # Metered/SSID/offline detection & policy
 │   └── __init__.py        # Public re-exports
-├── tests/                 # Focused Pytest modules (29 modules, ~462 tests)
+├── tests/                 # Focused Pytest modules (30 modules, ~465 tests)
 ├── scripts/               # CLI help capture, review bundles, icon generator
 ├── docs/                  # User + developer + reference docs
 ├── packaging/             # Linux nfpm + Windows Inno Setup

--- a/docs/developer-guide/architecture.md
+++ b/docs/developer-guide/architecture.md
@@ -116,7 +116,7 @@ immich-go-gui/
 │   ├── activity_monitor.py# Activity-based auto-pause detection
 │   ├── network_awareness.py # Metered/SSID/offline detection & policy
 │   └── __init__.py        # Public re-exports
-├── tests/                 # Focused Pytest modules (30 modules, ~468 tests)
+├── tests/                 # Focused Pytest modules (30 modules, ~469 tests)
 ├── scripts/               # CLI help capture, review bundles, icon generator
 ├── docs/                  # User + developer + reference docs
 ├── packaging/             # Linux nfpm + Windows Inno Setup

--- a/docs/developer-guide/testing.md
+++ b/docs/developer-guide/testing.md
@@ -1,6 +1,6 @@
 # Testing
 
-The test suite lives in `tests/` (462 tests across 29 modules) using `pytest` and `pytest-qt`.
+The test suite lives in `tests/` (465 tests across 30 modules) using `pytest` and `pytest-qt`.
 
 ## Running Tests
 

--- a/docs/developer-guide/testing.md
+++ b/docs/developer-guide/testing.md
@@ -1,6 +1,6 @@
 # Testing
 
-The test suite lives in `tests/` (465 tests across 30 modules) using `pytest` and `pytest-qt`.
+The test suite lives in `tests/` (468 tests across 30 modules) using `pytest` and `pytest-qt`.
 
 ## Running Tests
 

--- a/docs/developer-guide/testing.md
+++ b/docs/developer-guide/testing.md
@@ -1,6 +1,6 @@
 # Testing
 
-The test suite lives in `tests/` (468 tests across 30 modules) using `pytest` and `pytest-qt`.
+The test suite lives in `tests/` (469 tests across 30 modules) using `pytest` and `pytest-qt`.
 
 ## Running Tests
 

--- a/gui/mixins/app_update.py
+++ b/gui/mixins/app_update.py
@@ -1,6 +1,4 @@
 import webbrowser
-from importlib.metadata import PackageNotFoundError
-from importlib.metadata import version as _pkg_version
 
 from PySide6.QtCore import QObject, QRunnable, QThreadPool, Signal
 from PySide6.QtWidgets import QMessageBox
@@ -11,13 +9,7 @@ from core.app_update import (
     is_parseable_semver,
     is_update_available,
 )
-
-
-def _gui_version() -> str:
-    try:
-        return _pkg_version("immich-go-gui")
-    except PackageNotFoundError:
-        return "dev"
+from core.version import get_app_version as _gui_version
 
 
 class _UpdateCheckSignals(QObject):

--- a/gui/mixins/app_update.py
+++ b/gui/mixins/app_update.py
@@ -39,7 +39,11 @@ class AppUpdateMixin:
         installed = _gui_version()
         if hasattr(self, "lbl_app_version"):
             self.lbl_app_version.setText(installed)
-        if not is_parseable_semver(installed):
+        if (
+            not is_parseable_semver(installed)
+            or installed.endswith("-dev")
+            or installed == "dev"
+        ):
             self._set_app_update_status("Development build", "default")
         else:
             self._set_app_update_status(self._APP_UPDATE_STATUS_DEFAULT, "default")
@@ -72,7 +76,11 @@ class AppUpdateMixin:
     def check_for_application_updates(self) -> None:
         self._ensure_update_check_worker()
         installed = _gui_version()
-        is_dev = not is_parseable_semver(installed)
+        is_dev = (
+            not is_parseable_semver(installed)
+            or installed.endswith("-dev")
+            or installed == "dev"
+        )
         self._pending_update_check = (installed, is_dev)
         if hasattr(self, "btn_check_app_updates"):
             self.btn_check_app_updates.setEnabled(False)

--- a/gui/mixins/diagnostics.py
+++ b/gui/mixins/diagnostics.py
@@ -1,7 +1,5 @@
 import tomllib
 import zipfile
-from importlib.metadata import PackageNotFoundError
-from importlib.metadata import version as _pkg_version
 from pathlib import Path
 
 from PySide6.QtCore import QUrl
@@ -16,13 +14,7 @@ from core import (
     get_config_load_warning,
 )
 from core.profile_manager import profile_dir
-
-
-def _gui_version() -> str:
-    try:
-        return _pkg_version("immich-go-gui")
-    except PackageNotFoundError:
-        return "dev"
+from core.version import get_app_version as _gui_version
 
 
 def _redact_diagnostics_toml(text: str) -> str:

--- a/gui/mixins/menu.py
+++ b/gui/mixins/menu.py
@@ -1,6 +1,4 @@
 import webbrowser
-from importlib.metadata import PackageNotFoundError
-from importlib.metadata import version as _pkg_version
 from pathlib import Path
 
 from PySide6.QtGui import QAction
@@ -8,13 +6,7 @@ from PySide6.QtWidgets import QMessageBox
 
 from core import TESTED_IMMICH_GO_VERSION
 from core.profile_manager import active_profile_name, list_profiles
-
-
-def _gui_version() -> str:
-    try:
-        return _pkg_version("immich-go-gui")
-    except PackageNotFoundError:
-        return "dev"
+from core.version import get_app_version as _gui_version
 
 
 class MenuMixin:

--- a/scripts/sync_version.py
+++ b/scripts/sync_version.py
@@ -125,6 +125,11 @@ def main() -> int:
             'version = "{version}"',
         ),
         (
+            ROOT_DIR / "core" / "version.py",
+            r'^__version__\s*=\s*"[^"]+"',
+            '__version__ = "{version}"',
+        ),
+        (
             ROOT_DIR / ".github" / ".release-please-manifest.json",
             r'"\."(\s*:\s*)"[^"]+"',
             r'"."\g<1>"{version}"',

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,11 +1,13 @@
-"""Unit tests for core.version resolution and synchronization."""
+"""Unit tests for core.version resolution and environment detection."""
+
+from __future__ import annotations
 
 import re
 from pathlib import Path
 from unittest.mock import patch
 
 from core.app_update import is_parseable_semver
-from core.version import __version__, get_app_version
+from core.version import __version__, get_app_version, is_development_build
 
 ROOT_DIR = Path(__file__).resolve().parent.parent
 
@@ -17,17 +19,46 @@ def test_version_matches_pyproject():
     assert __version__ == match.group(1)
 
 
-def test_get_app_version_returns_valid_semver():
+def test_is_development_build_env_override(monkeypatch):
+    monkeypatch.setenv("IMMICH_GO_GUI_DEV", "1")
+    assert is_development_build() is True
+
+    monkeypatch.setenv("IMMICH_GO_GUI_DEV", "0")
+    assert is_development_build() is False
+
+
+def test_is_development_build_compiled_flag(monkeypatch):
+    monkeypatch.delenv("IMMICH_GO_GUI_DEV", raising=False)
+    monkeypatch.setattr("sys.__compiled__", True, raising=False)
+    assert is_development_build() is False
+
+
+def test_get_app_version_dev_mode(monkeypatch):
+    monkeypatch.setenv("IMMICH_GO_GUI_DEV", "1")
+    ver = get_app_version()
+    assert ver == f"{__version__}-dev"
+    assert is_parseable_semver(ver) is True
+
+
+def test_get_app_version_release_mode(monkeypatch):
+    monkeypatch.setenv("IMMICH_GO_GUI_DEV", "0")
     ver = get_app_version()
     assert ver == __version__
+    assert not ver.endswith("-dev")
     assert is_parseable_semver(ver) is True
 
 
 def test_get_app_version_fallback():
-    with patch("core.version.__version__", "dev"):
+    with (
+        patch("core.version.__version__", "dev"),
+        patch("core.version.is_development_build", return_value=False),
+    ):
         with patch("core.version._pkg_version", return_value="2.0.0"):
             assert get_app_version() == "2.0.0"
 
-    with patch("core.version.__version__", ""):
+    with (
+        patch("core.version.__version__", ""),
+        patch("core.version.is_development_build", return_value=False),
+    ):
         with patch("core.version._pkg_version", side_effect=Exception("not found")):
             assert get_app_version() == "dev"

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -33,6 +33,34 @@ def test_is_development_build_compiled_flag(monkeypatch):
     assert is_development_build() is False
 
 
+def test_is_development_build_git_detection(monkeypatch, tmp_path):
+    monkeypatch.delenv("IMMICH_GO_GUI_DEV", raising=False)
+    monkeypatch.delattr("sys.__compiled__", raising=False)
+    monkeypatch.delattr("sys.frozen", raising=False)
+
+    fake_version_file = tmp_path / "core" / "version.py"
+    fake_version_file.parent.mkdir(parents=True)
+    fake_version_file.touch()
+
+    monkeypatch.setattr("core.version.__file__", str(fake_version_file))
+
+    # Case 1: .git is a directory (standard git clone)
+    git_path = tmp_path / ".git"
+    git_path.mkdir()
+    assert is_development_build() is True
+
+    # Case 2: .git is a regular file (git worktree / submodule)
+    git_path.rmdir()
+    git_path.write_text(
+        "gitdir: /path/to/main/repo/.git/worktrees/feat\n", encoding="utf-8"
+    )
+    assert is_development_build() is True
+
+    # Case 3: .git does not exist
+    git_path.unlink()
+    assert is_development_build() is False
+
+
 def test_get_app_version_dev_mode(monkeypatch):
     monkeypatch.setenv("IMMICH_GO_GUI_DEV", "1")
     ver = get_app_version()

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,33 @@
+"""Unit tests for core.version resolution and synchronization."""
+
+import re
+from pathlib import Path
+from unittest.mock import patch
+
+from core.app_update import is_parseable_semver
+from core.version import __version__, get_app_version
+
+ROOT_DIR = Path(__file__).resolve().parent.parent
+
+
+def test_version_matches_pyproject():
+    pyproject_text = (ROOT_DIR / "pyproject.toml").read_text(encoding="utf-8")
+    match = re.search(r'^version\s*=\s*"([^"]+)"', pyproject_text, re.MULTILINE)
+    assert match is not None
+    assert __version__ == match.group(1)
+
+
+def test_get_app_version_returns_valid_semver():
+    ver = get_app_version()
+    assert ver == __version__
+    assert is_parseable_semver(ver) is True
+
+
+def test_get_app_version_fallback():
+    with patch("core.version.__version__", "dev"):
+        with patch("core.version._pkg_version", return_value="2.0.0"):
+            assert get_app_version() == "2.0.0"
+
+    with patch("core.version.__version__", ""):
+        with patch("core.version._pkg_version", side_effect=Exception("not found")):
+            assert get_app_version() == "dev"

--- a/uv.lock
+++ b/uv.lock
@@ -299,7 +299,7 @@ wheels = [
 
 [[package]]
 name = "immich-go-gui"
-version = "1.4.1"
+version = "1.4.2"
 source = { virtual = "." }
 dependencies = [
     { name = "idna" },


### PR DESCRIPTION
## Summary
- Resolves issue where installed DEB packages, standalone Nuitka binaries, and local dev environments reported `dev` / "Development build" due to missing `importlib.metadata` package metadata.
- Implements static `__version__` in `core/version.py` with `get_app_version()` fallback.
- Centralizes version discovery across `gui.mixins.app_update`, `gui.mixins.menu`, `gui.mixins.diagnostics`, and `gui.tabs.config_tab`.
- Adds `core/version.py` to `scripts/sync_version.py` targets and `.github/release-please-config.json` `extra-files` for automated release synchronization.
- Adds test suite in `tests/test_version.py` and updates test counts.

## Verification
- `uv run pre-commit run --all-files` (PASSED)
- `uv run ty check core/` (PASSED)
- `uv run python app.py --self-test` (PASSED)
- `uv run python scripts/sync_version.py --check` (PASSED)
- `uv run pytest` (448 passed, 10 skipped, 7 deselected)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added centralized application version reporting across the app.
  * Development builds now display a `-dev` version suffix when detected.
  * Exposed version information for broader application use.

* **Bug Fixes**
  * Improved version detection when package metadata is unavailable.

* **Documentation**
  * Updated documented test suite totals to 469 tests across 30 modules.

* **Tests**
  * Added coverage for development-build detection, version formatting, synchronization, and fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->